### PR TITLE
Add CI check to block PRs targeting backplane branches

### DIFF
--- a/.github/workflows/protect-backplane-branches.yaml
+++ b/.github/workflows/protect-backplane-branches.yaml
@@ -1,0 +1,16 @@
+name: Protect backplane branches
+
+on:
+  pull_request:
+    branches:
+      - "backplane-*"
+
+jobs:
+  block:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Block PR
+        run: |
+          echo "::error::Direct pull requests to backplane branches are not accepted."
+          echo "::error::Changes are synced from main via fast-forward. Please target your PR to the main branch instead."
+          exit 1

--- a/.github/workflows/protect-backplane-branches.yaml
+++ b/.github/workflows/protect-backplane-branches.yaml
@@ -4,6 +4,11 @@ on:
   pull_request:
     branches:
       - "backplane-*"
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - edited
 
 permissions: {}
 

--- a/.github/workflows/protect-backplane-branches.yaml
+++ b/.github/workflows/protect-backplane-branches.yaml
@@ -5,6 +5,8 @@ on:
     branches:
       - "backplane-*"
 
+permissions: {}
+
 jobs:
   block:
     runs-on: ubuntu-latest

--- a/.github/workflows/protect-backplane-branches.yaml
+++ b/.github/workflows/protect-backplane-branches.yaml
@@ -3,7 +3,7 @@ name: Protect backplane branches
 on:
   pull_request:
     branches:
-      - "backplane-*"
+      - "backplane-5*"
     types:
       - opened
       - reopened
@@ -18,6 +18,6 @@ jobs:
     steps:
       - name: Block PR
         run: |
-          echo "::error::Direct pull requests to backplane branches are not accepted."
+          echo "::error::Direct pull requests to backplane-5.x branches are not accepted."
           echo "::error::Changes are synced from main via fast-forward. Please target your PR to the main branch instead."
           exit 1


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow that fails any PR targeting `backplane-*` branches
- Backplane branches are synced from `main` via fast-forward (`ffwd-branch.yaml`), so direct PRs are unnecessary and can cause divergence
- The workflow prints a clear error message directing contributors to target `main` instead
- Includes `edited` event type to catch PRs retargeted to backplane branches
- Uses `permissions: {}` for minimal token scope

Ref: [ARO-27157](https://redhat.atlassian.net/browse/ARO-27157)

## Test plan

- [ ] Open a test PR targeting `backplane-5.0` — verify the `block` job fails with the error message
- [ ] Retarget an existing PR to `backplane-5.0` — verify it also triggers the block
- [ ] Verify FFWD sync still works on next push to `main`
- [ ] Verify existing PRs targeting `main` are unaffected

[ARO-27157]: https://redhat.atlassian.net/browse/ARO-27157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added protection to backplane release branches to enforce contribution workflow. Direct pull requests to these branches are now automatically blocked, with changes required to originate from the main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->