### PR TITLE
Add upstream sync workflow (ARO-27155)

### DIFF
--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -42,11 +42,8 @@ jobs:
       - name: Find new upstream commits
         id: find-commits
         run: |
-          COMMITS=$(git log --format="%H" --reverse origin/main..upstream/main)
-          COMMIT_COUNT=0
-          if [ -n "$COMMITS" ]; then
-            COMMIT_COUNT=$(echo "$COMMITS" | wc -l)
-          fi
+          mapfile -t COMMITS < <(git cherry origin/main upstream/main | awk '/^\+ / {print $2}')
+          COMMIT_COUNT=${#COMMITS[@]}
           echo "count=${COMMIT_COUNT}" >> "$GITHUB_OUTPUT"
 
           if [ "$COMMIT_COUNT" -eq 0 ]; then
@@ -71,9 +68,9 @@ jobs:
           git checkout -b "$BRANCH"
           echo "branch=${BRANCH}" >> "$GITHUB_OUTPUT"
 
-          # Cherry-pick each commit in chronological order
-          SHAS=$(git log --format="%H" --reverse origin/main..upstream/main)
-          TOTAL=$(echo "$SHAS" | wc -l)
+          # Cherry-pick each commit in chronological order (patch-equivalence)
+          mapfile -t SHAS < <(git cherry origin/main upstream/main | awk '/^\+ / {print $2}')
+          TOTAL=${#SHAS[@]}
           APPLIED=0
           CONFLICT_SHA=""
           CONFLICT_TITLE=""
@@ -82,7 +79,7 @@ jobs:
           REMAINING_LINES=""
           HIT_CONFLICT=false
 
-          for SHA in $SHAS; do
+          for SHA in "${SHAS[@]}"; do
             TITLE=$(git log --format="%s" -1 "$SHA")
             SHORT=$(echo "$SHA" | cut -c1-8)
 

--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -128,7 +128,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Push and create draft PR
-        if: steps.cherry-pick.outputs.applied != '0'
+        if: steps.find-commits.outputs.count != '0' && steps.cherry-pick.outputs.applied != '0'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SYNC_BRANCH: ${{ steps.cherry-pick.outputs.branch }}

--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -1,0 +1,200 @@
+---
+name: Upstream Sync
+
+on:
+  schedule:
+    - cron: '17 8 * * 1' # Every Monday at 08:17 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git
+        run: |
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+
+      - name: Add upstream remote and fetch
+        run: |
+          git remote add upstream https://github.com/Azure/azure-service-operator.git
+          git fetch upstream main
+
+      - name: Find new upstream commits
+        id: find-commits
+        run: |
+          COMMITS=$(git log --format="%H" --reverse origin/main..upstream/main)
+          COMMIT_COUNT=0
+          if [ -n "$COMMITS" ]; then
+            COMMIT_COUNT=$(echo "$COMMITS" | wc -l)
+          fi
+          echo "count=${COMMIT_COUNT}" >> "$GITHUB_OUTPUT"
+
+          if [ "$COMMIT_COUNT" -eq 0 ]; then
+            echo "No new upstream commits found."
+          else
+            echo "Found ${COMMIT_COUNT} new upstream commits."
+          fi
+
+      - name: Cherry-pick commits
+        if: steps.find-commits.outputs.count != '0'
+        id: cherry-pick
+        run: |
+          # Determine sync branch name (avoid collisions)
+          DATE=$(date +%Y-%m-%d)
+          BRANCH="upstream-sync/${DATE}"
+          SUFFIX=1
+          while git ls-remote --heads origin "${BRANCH}" 2>/dev/null | grep -q .; do
+            SUFFIX=$((SUFFIX + 1))
+            BRANCH="upstream-sync/${DATE}-${SUFFIX}"
+          done
+
+          git checkout -b "$BRANCH"
+          echo "branch=${BRANCH}" >> "$GITHUB_OUTPUT"
+
+          # Cherry-pick each commit in chronological order
+          SHAS=$(git log --format="%H" --reverse origin/main..upstream/main)
+          TOTAL=$(echo "$SHAS" | wc -l)
+          APPLIED=0
+          CONFLICT_SHA=""
+          CONFLICT_TITLE=""
+          CONFLICT_FULL_SHA=""
+          APPLIED_LINES=""
+          REMAINING_LINES=""
+          HIT_CONFLICT=false
+
+          for SHA in $SHAS; do
+            TITLE=$(git log --format="%s" -1 "$SHA")
+            SHORT=$(echo "$SHA" | cut -c1-8)
+
+            if [ "$HIT_CONFLICT" = true ]; then
+              REMAINING_LINES=$(printf '%s\n- `%s` %s' "$REMAINING_LINES" "$SHORT" "$TITLE")
+              continue
+            fi
+
+            if git cherry-pick "$SHA" --no-edit 2>/dev/null; then
+              APPLIED=$((APPLIED + 1))
+              APPLIED_LINES=$(printf '%s\n- `%s` %s' "$APPLIED_LINES" "$SHORT" "$TITLE")
+              echo "✅ Applied: ${SHORT} ${TITLE}"
+            else
+              git cherry-pick --abort 2>/dev/null || true
+              HIT_CONFLICT=true
+              CONFLICT_SHA="$SHORT"
+              CONFLICT_TITLE="$TITLE"
+              CONFLICT_FULL_SHA="$SHA"
+              echo "❌ Conflict: ${SHORT} ${TITLE}"
+            fi
+          done
+
+          echo "applied=${APPLIED}" >> "$GITHUB_OUTPUT"
+          echo "total=${TOTAL}" >> "$GITHUB_OUTPUT"
+          echo "conflict_sha=${CONFLICT_SHA}" >> "$GITHUB_OUTPUT"
+          echo "conflict_full_sha=${CONFLICT_FULL_SHA}" >> "$GITHUB_OUTPUT"
+
+          # Multiline outputs via heredoc delimiter
+          DELIM="UPSTREAM_SYNC_EOF_$(date +%s)"
+          {
+            echo "conflict_title<<${DELIM}"
+            echo "$CONFLICT_TITLE"
+            echo "${DELIM}"
+          } >> "$GITHUB_OUTPUT"
+          {
+            echo "applied_lines<<${DELIM}"
+            echo "$APPLIED_LINES"
+            echo "${DELIM}"
+          } >> "$GITHUB_OUTPUT"
+          {
+            echo "remaining_lines<<${DELIM}"
+            echo "$REMAINING_LINES"
+            echo "${DELIM}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Push and create draft PR
+        if: steps.cherry-pick.outputs.applied != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCH="${{ steps.cherry-pick.outputs.branch }}"
+          APPLIED="${{ steps.cherry-pick.outputs.applied }}"
+          TOTAL="${{ steps.cherry-pick.outputs.total }}"
+          CONFLICT_SHA="${{ steps.cherry-pick.outputs.conflict_sha }}"
+          CONFLICT_TITLE="${{ steps.cherry-pick.outputs.conflict_title }}"
+          CONFLICT_FULL_SHA="${{ steps.cherry-pick.outputs.conflict_full_sha }}"
+          DATE=$(date +%Y-%m-%d)
+
+          git push origin "$BRANCH"
+
+          # Build PR body
+          {
+            echo "## Upstream Sync — ${DATE}"
+            echo ""
+            echo "Applied **${APPLIED}/${TOTAL}** commits from [Azure/azure-service-operator](https://github.com/Azure/azure-service-operator) main."
+            echo ""
+            echo "### Applied"
+            echo "${{ steps.cherry-pick.outputs.applied_lines }}"
+            echo ""
+
+            if [ -n "$CONFLICT_SHA" ]; then
+              echo "### ❌ Conflict"
+              echo "- \`${CONFLICT_SHA}\` ${CONFLICT_TITLE}"
+              echo ""
+
+              REMAINING="${{ steps.cherry-pick.outputs.remaining_lines }}"
+              if [ -n "$REMAINING" ]; then
+                echo "### Remaining (not attempted)"
+                echo "$REMAINING"
+                echo ""
+              fi
+
+              echo "### How to resolve"
+              echo "1. **Merge this PR** — it contains all cleanly applied commits"
+              echo "2. **Resolve the conflict locally:**"
+              echo '```bash'
+              echo "git checkout main && git pull"
+              echo "git cherry-pick ${CONFLICT_FULL_SHA}"
+              echo "# fix conflicts"
+              echo "git add . && git cherry-pick --continue"
+              echo "git push origin main"
+              echo '```'
+              echo "3. **Re-run this workflow** (Actions → Upstream Sync → Run workflow)"
+              echo "4. **Repeat** until all upstream commits are applied"
+              echo ""
+              echo "Once all commits are synced, the weekly schedule maintains alignment automatically."
+            fi
+          } > /tmp/pr-body.md
+
+          gh pr create \
+            --title "Upstream sync ${DATE}: ${APPLIED}/${TOTAL} commits" \
+            --body-file /tmp/pr-body.md \
+            --base main \
+            --head "$BRANCH" \
+            --draft
+
+      - name: Report when first commit conflicts
+        if: steps.find-commits.outputs.count != '0' && steps.cherry-pick.outputs.applied == '0'
+        run: |
+          echo "::warning::The first upstream commit conflicts and no PR was created."
+          echo ""
+          echo "Conflicting commit:"
+          echo "  SHA:   ${{ steps.cherry-pick.outputs.conflict_full_sha }}"
+          echo "  Title: ${{ steps.cherry-pick.outputs.conflict_title }}"
+          echo ""
+          echo "Resolve manually:"
+          echo "  git checkout main && git pull"
+          echo "  git cherry-pick ${{ steps.cherry-pick.outputs.conflict_full_sha }}"
+          echo "  # resolve conflicts"
+          echo "  git add . && git cherry-pick --continue"
+          echo "  git push origin main"
+          echo ""
+          echo "Then re-run this workflow."

--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -13,10 +13,13 @@ permissions:
 jobs:
   sync:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pinned to 4.1.7
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -83,7 +86,7 @@ jobs:
               continue
             fi
 
-            if git cherry-pick "$SHA" --no-edit 2>/dev/null; then
+            if git cherry-pick --no-edit "$SHA"; then
               APPLIED=$((APPLIED + 1))
               APPLIED_LINES=$(printf '%s\n- `%s` %s' "$APPLIED_LINES" "$SHORT" "$TITLE")
               echo "✅ Applied: ${SHORT} ${TITLE}"
@@ -103,37 +106,38 @@ jobs:
           echo "conflict_full_sha=${CONFLICT_FULL_SHA}" >> "$GITHUB_OUTPUT"
 
           # Multiline outputs via heredoc delimiter
-          DELIM="UPSTREAM_SYNC_EOF_$(date +%s)"
           {
-            echo "conflict_title<<${DELIM}"
+            echo "conflict_title<<CONFLICT_TITLE_EOF"
             echo "$CONFLICT_TITLE"
-            echo "${DELIM}"
+            echo "CONFLICT_TITLE_EOF"
           } >> "$GITHUB_OUTPUT"
           {
-            echo "applied_lines<<${DELIM}"
+            echo "applied_lines<<APPLIED_LINES_EOF"
             echo "$APPLIED_LINES"
-            echo "${DELIM}"
+            echo "APPLIED_LINES_EOF"
           } >> "$GITHUB_OUTPUT"
           {
-            echo "remaining_lines<<${DELIM}"
+            echo "remaining_lines<<REMAINING_LINES_EOF"
             echo "$REMAINING_LINES"
-            echo "${DELIM}"
+            echo "REMAINING_LINES_EOF"
           } >> "$GITHUB_OUTPUT"
 
       - name: Push and create draft PR
         if: steps.cherry-pick.outputs.applied != '0'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SYNC_BRANCH: ${{ steps.cherry-pick.outputs.branch }}
+          APPLIED: ${{ steps.cherry-pick.outputs.applied }}
+          TOTAL: ${{ steps.cherry-pick.outputs.total }}
+          CONFLICT_SHA: ${{ steps.cherry-pick.outputs.conflict_sha }}
+          CONFLICT_TITLE: ${{ steps.cherry-pick.outputs.conflict_title }}
+          CONFLICT_FULL_SHA: ${{ steps.cherry-pick.outputs.conflict_full_sha }}
+          APPLIED_LINES: ${{ steps.cherry-pick.outputs.applied_lines }}
+          REMAINING_LINES: ${{ steps.cherry-pick.outputs.remaining_lines }}
         run: |
-          BRANCH="${{ steps.cherry-pick.outputs.branch }}"
-          APPLIED="${{ steps.cherry-pick.outputs.applied }}"
-          TOTAL="${{ steps.cherry-pick.outputs.total }}"
-          CONFLICT_SHA="${{ steps.cherry-pick.outputs.conflict_sha }}"
-          CONFLICT_TITLE="${{ steps.cherry-pick.outputs.conflict_title }}"
-          CONFLICT_FULL_SHA="${{ steps.cherry-pick.outputs.conflict_full_sha }}"
           DATE=$(date +%Y-%m-%d)
 
-          git push origin "$BRANCH"
+          git push origin "$SYNC_BRANCH"
 
           # Build PR body
           {
@@ -142,7 +146,7 @@ jobs:
             echo "Applied **${APPLIED}/${TOTAL}** commits from [Azure/azure-service-operator](https://github.com/Azure/azure-service-operator) main."
             echo ""
             echo "### Applied"
-            echo "${{ steps.cherry-pick.outputs.applied_lines }}"
+            echo "$APPLIED_LINES"
             echo ""
 
             if [ -n "$CONFLICT_SHA" ]; then
@@ -150,10 +154,9 @@ jobs:
               echo "- \`${CONFLICT_SHA}\` ${CONFLICT_TITLE}"
               echo ""
 
-              REMAINING="${{ steps.cherry-pick.outputs.remaining_lines }}"
-              if [ -n "$REMAINING" ]; then
+              if [ -n "$REMAINING_LINES" ]; then
                 echo "### Remaining (not attempted)"
-                echo "$REMAINING"
+                echo "$REMAINING_LINES"
                 echo ""
               fi
 
@@ -178,21 +181,24 @@ jobs:
             --title "Upstream sync ${DATE}: ${APPLIED}/${TOTAL} commits" \
             --body-file /tmp/pr-body.md \
             --base main \
-            --head "$BRANCH" \
+            --head "$SYNC_BRANCH" \
             --draft
 
       - name: Report when first commit conflicts
         if: steps.find-commits.outputs.count != '0' && steps.cherry-pick.outputs.applied == '0'
+        env:
+          CONFLICT_FULL_SHA: ${{ steps.cherry-pick.outputs.conflict_full_sha }}
+          CONFLICT_TITLE: ${{ steps.cherry-pick.outputs.conflict_title }}
         run: |
           echo "::warning::The first upstream commit conflicts and no PR was created."
           echo ""
           echo "Conflicting commit:"
-          echo "  SHA:   ${{ steps.cherry-pick.outputs.conflict_full_sha }}"
-          echo "  Title: ${{ steps.cherry-pick.outputs.conflict_title }}"
+          echo "  SHA:   ${CONFLICT_FULL_SHA}"
+          echo "  Title: ${CONFLICT_TITLE}"
           echo ""
           echo "Resolve manually:"
           echo "  git checkout main && git pull"
-          echo "  git cherry-pick ${{ steps.cherry-pick.outputs.conflict_full_sha }}"
+          echo "  git cherry-pick ${CONFLICT_FULL_SHA}"
           echo "  # resolve conflicts"
           echo "  git add . && git cherry-pick --continue"
           echo "  git push origin main"

--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -13,6 +13,10 @@ permissions:
 jobs:
   sync:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    concurrency:
+      group: upstream-sync
+      cancel-in-progress: false
     defaults:
       run:
         shell: bash
@@ -105,21 +109,24 @@ jobs:
           echo "conflict_sha=${CONFLICT_SHA}" >> "$GITHUB_OUTPUT"
           echo "conflict_full_sha=${CONFLICT_FULL_SHA}" >> "$GITHUB_OUTPUT"
 
-          # Multiline outputs via heredoc delimiter
+          # Multiline outputs via randomized heredoc delimiters to prevent injection
+          DELIM=$(openssl rand -hex 16)
           {
-            echo "conflict_title<<CONFLICT_TITLE_EOF"
+            echo "conflict_title<<${DELIM}"
             echo "$CONFLICT_TITLE"
-            echo "CONFLICT_TITLE_EOF"
+            echo "${DELIM}"
           } >> "$GITHUB_OUTPUT"
+          DELIM=$(openssl rand -hex 16)
           {
-            echo "applied_lines<<APPLIED_LINES_EOF"
+            echo "applied_lines<<${DELIM}"
             echo "$APPLIED_LINES"
-            echo "APPLIED_LINES_EOF"
+            echo "${DELIM}"
           } >> "$GITHUB_OUTPUT"
+          DELIM=$(openssl rand -hex 16)
           {
-            echo "remaining_lines<<REMAINING_LINES_EOF"
+            echo "remaining_lines<<${DELIM}"
             echo "$REMAINING_LINES"
-            echo "REMAINING_LINES_EOF"
+            echo "${DELIM}"
           } >> "$GITHUB_OUTPUT"
 
       - name: Push and create draft PR

--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -27,6 +27,7 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
+          ref: main
 
       - name: Configure git
         run: |


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/upstream-sync.yml` — weekly cherry-pick sync from upstream Azure/azure-service-operator
- Triggers: weekly cron (Monday 08:17 UTC) + manual workflow_dispatch
- Creates draft PRs with individually cherry-picked commits
- Stops at first conflict and includes resolution instructions in PR body
- Uses `git cherry` for patch-equivalence detection — already-synced commits are skipped on subsequent runs
- Checkout pinned to `ref: main` so `workflow_dispatch` from non-main refs works correctly
- Security: all untrusted data (commit titles) passed via env vars, never via `${{ }}` interpolation in shell scripts; randomized heredoc delimiters for multiline `GITHUB_OUTPUT`
- Hardening: `concurrency` block prevents duplicate PRs from parallel runs; `timeout-minutes: 30` prevents runaway jobs

## Jira
- [ARO-27155](https://redhat.atlassian.net/browse/ARO-27155) (subtask of ARO-26907: CAPZ maintenance)

## Test plan
- [x] YAML validates
- [ ] After merge, trigger manual run via Actions → Upstream Sync → Run workflow
- [ ] Verify draft PR is created with expected commit list and formatting
- [ ] If conflicts occur, verify resolution instructions are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ARO-27155]: https://redhat.atlassian.net/browse/ARO-27155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ