### PR TITLE
Add FIPS GOEXPERIMENT flag and use floating builder tag

### DIFF
--- a/stolostron/Dockerfile.stolostron
+++ b/stolostron/Dockerfile.stolostron
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.25.9-1778675823 AS toolchain
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25 AS toolchain
 
 # Run this with docker build --build_arg $(go env GOPROXY) to override the goproxy
 ARG goproxy=https://proxy.golang.org
@@ -23,7 +23,7 @@ RUN  --mount=type=cache,target=/root/.local/share/golang \
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.local/share/golang \
-    CGO_ENABLED=1 GOOS=linux GOARCH=${ARCH} go build -o ./aso-controller ./cmd/controller/
+    CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime GOOS=linux GOARCH=${ARCH} go build -o ./aso-controller ./cmd/controller/
 
 # Copy the aso-controller into a thin image
 FROM registry.access.redhat.com/ubi9/ubi:9.7-1778461714


### PR DESCRIPTION
## Summary
- Add `GOEXPERIMENT=strictfipsruntime` to go build command for FIPS compliance
- Switch builder to floating tag `ubi9/go-toolset:1.25` (from pinned `1.25.9-1778675823`)

JIRA: HYPBLD-844