### PR TITLE
ARO-26782 - add additional-tags for backplane-2.11

### DIFF
--- a/.tekton/azure-service-operator-mce-211-pull-request.yaml
+++ b/.tekton/azure-service-operator-mce-211-pull-request.yaml
@@ -25,6 +25,9 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/azure-service-operator-mce-211:on-pr-{{revision}}
+  - name: additional-tags
+    value:
+    - 2.11.0-pr-{{pull_request_number}}
   - name: image-expires-after
     value: 5d
   - name: build-platforms

--- a/.tekton/azure-service-operator-mce-211-push.yaml
+++ b/.tekton/azure-service-operator-mce-211-push.yaml
@@ -24,6 +24,9 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/azure-service-operator-mce-211:{{revision}}
+  - name: additional-tags
+    value:
+    - 2.11.0-latest
   - name: build-platforms
     value:
     - linux/x86_64


### PR DESCRIPTION
## What this PR does

* for [ARO-26782](https://redhat.atlassian.net/browse/ARO-26782) add aditional docker image tags:
  * for the latest Konflux build `2.11.0-latest`
  * for curent PR Konflux build  `2.11.0-pr-<pr-no>`

[ARO-26782]: https://redhat.atlassian.net/browse/ARO-26782?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline configuration to add version tagging for builds with scheme `2.11.0`, differentiating between pull request builds (with PR identifier) and release builds (with latest tag).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->