### PR TITLE
fix: restrict Renovate to only tekton and dockerfile managers

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "enabledManagers": [
+    "tekton",
+    "dockerfile"
+  ],
   "baseBranchPatterns": [
     "main",
-    "/^backplane-2\\.[0-99]$/"
+    "/^backplane-2\\.[0-9]+$/"
   ],
   "tekton": {
     "includePaths": [
@@ -17,6 +21,12 @@
       "matchManagers": [
         "dockerfile"
       ],
+      "enabled": false
+    },
+    {
+      "matchManagers": [
+        "dockerfile"
+      ],
       "enabled": true,
       "matchFileNames": [
         "stolostron/Dockerfile.stolostron"
@@ -25,7 +35,7 @@
     {
       "matchBaseBranches": [
         "main",
-        "/^backplane-2\\.[0-99]$/"
+        "/^backplane-2\\.[0-9]+$/"
       ],
       "matchManagers": [
         "tekton"
@@ -34,12 +44,6 @@
       "addLabels": [
         "ok-to-test"
       ]
-    },
-    {
-      "matchManagers": [
-        "gomod"
-      ],
-      "enabled": false
     }
   ],
   "rebaseWhen": "behind-base-branch",


### PR DESCRIPTION
## Summary

Aligns the ASO Renovate configuration with the working [CAPZ configuration](https://github.com/stolostron/cluster-api-provider-azure/blob/main/renovate.json) to eliminate unwanted automated dependency PRs.

**The problem:** ASO currently has **19 open unwanted dependency PRs** from MintMaker/Renovate, while CAPZ (configured correctly) has **zero**. The root cause is that ASO was missing the `enabledManagers` whitelist, so all ~50 Renovate package managers were active.

## What changed

### 1. Added `enabledManagers` whitelist (the key fix)

```json
"enabledManagers": ["tekton", "dockerfile"]
```

Without this, Renovate enables **all** package managers by default and then applies `packageRules` to disable specific ones. The ASO config only disabled `gomod`, leaving `github-actions`, `docker-compose`, `git-submodules`, and many others active — generating PRs for dependencies that are already updated from upstream syncs.

With the whitelist, **only** Tekton and Dockerfile managers run — the two categories that manage fork-specific files (`stolostron/Dockerfile.stolostron` and `.tekton/` pipelines) which won't come from upstream.

### 2. Added "disable all Dockerfiles first" rule

CAPZ uses a two-step pattern: first disable ALL Dockerfile updates, then re-enable only for `stolostron/Dockerfile.stolostron`. ASO was missing the first step, so Renovate was updating all Dockerfiles it found (e.g., the `ubi9/ubi` docker tag PR).

### 3. Fixed branch regex pattern

| Before | After |
|--------|-------|
| `/^backplane-2\\.[0-99]$/` | `/^backplane-2\\.[0-9]+$/` |

`[0-99]` is a character class matching single digits only. The `+` quantifier is needed to match multi-digit versions like `backplane-2.10`.

### 4. Removed redundant `gomod` disable rule

No longer needed since `enabledManagers` excludes `gomod` entirely.

## Categories of unwanted PRs this fixes

| Category | # Open PRs | Why unwanted |
|----------|-----------|--------------|
| Go modules | 12 | Updated from upstream |
| GitHub Actions | 4 | Updated from upstream |
| Dockerfile (non-stolostron) | 1 | Updated from upstream |
| Submodule digests | 2 | Updated from upstream |

## Test plan

- [ ] Verify MintMaker/Renovate stops creating new PRs for go modules, github-actions, and submodules
- [ ] Verify Tekton pipeline updates still work (`.tekton/` directory)
- [ ] Verify `stolostron/Dockerfile.stolostron` updates still work
- [ ] Consider closing the 19 existing unwanted PRs after merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to improve handling of automated dependency updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->