### PR TITLE
ARO-27315 - Sync HCP OpenShift cluster admin credential poller resume token changes from 2.17

### DIFF
--- a/v2/api/redhatopenshift/customizations/hcp_open_shift_cluster_extension.go
+++ b/v2/api/redhatopenshift/customizations/hcp_open_shift_cluster_extension.go
@@ -5,6 +5,7 @@ package customizations
 import (
 	"context"
 	"strings"
+	"time"
 
 	. "github.com/Azure/azure-service-operator/v2/internal/logging"
 
@@ -70,27 +71,6 @@ func (ext *HcpOpenShiftClusterExtension) PreReconcileCheck(ctx context.Context,
 
 var _ genruntime.KubernetesSecretExporter = &HcpOpenShiftClusterExtension{}
 
-const (
-	BackupInstancePollerResumeTokenAnnotation = "serviceoperator.azure.com/bi-poller-resume-token"
-)
-
-func GetPollerResumeToken(obj genruntime.MetaObject, log logr.Logger) (string, bool) {
-	log.V(Debug).Info("GetPollerResumeToken")
-	token, hasResumeToken := obj.GetAnnotations()[BackupInstancePollerResumeTokenAnnotation]
-	return token, hasResumeToken
-}
-
-func SetPollerResumeToken(obj genruntime.MetaObject, token string, log logr.Logger) {
-	log.V(Debug).Info("SetPollerResumeToken")
-	genruntime.AddAnnotation(obj, BackupInstancePollerResumeTokenAnnotation, token)
-}
-
-// ClearPollerResumeToken clears the poller resume token and ID annotations
-func ClearPollerResumeToken(obj genruntime.MetaObject, log logr.Logger) {
-	log.V(Debug).Info("ClearPollerResumeToken")
-	genruntime.RemoveAnnotation(obj, BackupInstancePollerResumeTokenAnnotation)
-}
-
 func (ext *HcpOpenShiftClusterExtension) ExportKubernetesSecrets(
 	ctx context.Context,
 	obj genruntime.MetaObject,
@@ -133,37 +113,35 @@ func (ext *HcpOpenShiftClusterExtension) ExportKubernetesSecrets(
 
 	var adminCredentials string
 	if requestedSecrets.Contains(adminCredentialsKey) {
-		resumeToken, _ := GetPollerResumeToken(typedObj, log)
-		opts := &armstorage.HcpOpenShiftClustersClientBeginRequestAdminCredentialOptions{ResumeToken: resumeToken}
 		log.V(Debug).Info("Starting BeginRequestAdminCredential")
 		var poller *runtime.Poller[armstorage.HcpOpenShiftClustersClientRequestAdminCredentialResponse]
-		poller, err = clusterClient.BeginRequestAdminCredential(ctx, id.ResourceGroupName, typedObj.AzureName(), opts)
+		poller, err = clusterClient.BeginRequestAdminCredential(ctx, id.ResourceGroupName, typedObj.AzureName(), nil)
 		if err != nil {
 			return nil, eris.Wrapf(err, "failed creating admin credentials")
 		}
-		if resumeToken == "" {
-			resumeToken, resumeTokenErr := poller.ResumeToken()
-			if resumeTokenErr != nil {
-				return nil, eris.Wrapf(resumeTokenErr, "couldn't create PUT resume token for resource")
-			} else {
-				SetPollerResumeToken(obj, resumeToken, log)
-			}
-		}
-		_, pollErr := poller.Poll(ctx)
+
+		log.V(Debug).Info("Waiting for admin credential request to complete")
+		pollCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+		defer cancel()
+		resp, pollErr := poller.PollUntilDone(pollCtx, &runtime.PollUntilDoneOptions{
+			Frequency: 15 * time.Second,
+		})
 		if pollErr != nil {
-			return nil, eris.Wrapf(pollErr, "couldn't poll with PUT resume token for resource")
+			if ctx.Err() != nil {
+				return nil, eris.Wrapf(pollErr, "parent context cancelled while waiting for admin credentials")
+			}
+			if pollCtx.Err() == context.DeadlineExceeded {
+				return nil, eris.Wrapf(pollErr, "timed out after 5 minutes waiting for admin credentials to be ready")
+			}
+			return nil, eris.Wrapf(pollErr, "failed waiting for admin credentials to be ready")
 		}
 
-		if poller.Done() {
-			log.V(Debug).Info("Polling is completed")
-			ClearPollerResumeToken(obj, log)
-			resp, err := poller.Result(ctx)
-			if err != nil {
-				return nil, eris.Wrapf(err, "couldn't get result with PUT resume token for resource")
-			}
-			adminCredentials = to.Value(resp.HcpOpenShiftClusterAdminCredential.Kubeconfig)
-		} else {
-			log.V(Debug).Info("Polling is in-progress")
+		log.V(Debug).Info("Admin credential request completed")
+		adminCredentials = to.Value(resp.HcpOpenShiftClusterAdminCredential.Kubeconfig)
+		if adminCredentials == "" {
+			return nil, eris.Errorf(
+				"admin credential response for cluster %s in resource group %s contained an empty kubeconfig",
+				typedObj.AzureName(), id.ResourceGroupName)
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Syncs admin credential poller changes from backplane-2.17 to backplane-2.11
- Replaces non-blocking single `Poll` with resume token persistence back to blocking `PollUntilDone` with 5-minute timeout
- Removes poller resume token annotation handling (Get/Set/Clear functions)

## References
- Jira: [ARO-27315](https://redhat.atlassian.net/browse/ARO-27315)
- Parent epic: [ARO-26907](https://redhat.atlassian.net/browse/ARO-26907)
- Related: [ARO-27266](https://redhat.atlassian.net/browse/ARO-27266)

## Test plan
- [ ] Verify admin credential export works with PollUntilDone approach
- [ ] Confirm no false permanent failure detection in AROControlPlane conditions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ARO-27315]: https://redhat.atlassian.net/browse/ARO-27315?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ARO-26907]: https://redhat.atlassian.net/browse/ARO-26907?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ARO-27266]: https://redhat.atlassian.net/browse/ARO-27266?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored OpenShift admin credential request polling to implement fixed time-bounded polling with a 5-minute timeout and 15-second interval between attempts
  * Improved error messages to provide explicit feedback regarding timeout and cancellation scenarios during credential requests
  * Streamlined credential request workflow for improved reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->