### PR TITLE
ARO-27434 - restrict GITHUB_TOKEN permissions in workflows

### DIFF
--- a/.github/workflows/create-release-experimental.yml
+++ b/.github/workflows/create-release-experimental.yml
@@ -11,6 +11,8 @@ on:
   # no content, allows manual triggering
   workflow_dispatch:
 
+permissions: {}
+
 env:
   ARTIFACT_VERSION: experimental
 

--- a/.github/workflows/create-release-official.yml
+++ b/.github/workflows/create-release-official.yml
@@ -7,6 +7,8 @@ on:
     tags:
       - v2*
 
+permissions: {}
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest

--- a/.github/workflows/create-release-stolostron.yml
+++ b/.github/workflows/create-release-stolostron.yml
@@ -7,6 +7,8 @@ on:
     tags:
       - v2*
 
+permissions: {}
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest

--- a/.github/workflows/ffwd-branch.yaml
+++ b/.github/workflows/ffwd-branch.yaml
@@ -7,12 +7,13 @@ on:
       - main
 
 
-permissions:
-  contents: write
+permissions: {}
 
 jobs:
   fast-forward:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     env:
       TARGET_BRANCHES: backplane-5.0 backplane-5.1
 

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -15,6 +15,8 @@ on:
       - main
     types: [checks_requested]
 
+permissions: {}
+
 jobs:
   test-go-get:
     runs-on: ubuntu-latest

--- a/.github/workflows/weekly-security-scan.yaml
+++ b/.github/workflows/weekly-security-scan.yaml
@@ -6,13 +6,14 @@ on:
     - cron: "0 12 * * 1"
   workflow_dispatch:
 
-permissions:
-  contents: read
-  security-events: write
-  issues: write
+permissions: {}
 
 jobs:
   scan:
+    permissions:
+      contents: read
+      security-events: write
+      issues: write
     concurrency:
       group: weekly-security-scan-${{ matrix.branch }}
       cancel-in-progress: false


### PR DESCRIPTION
## Summary

Restrict overly broad `GITHUB_TOKEN` permissions across 6 workflows flagged by OpenSSF Scorecard (HIGH severity alerts #65, #71, #72, #73, #74, #75).

JIRA: https://redhat.atlassian.net/browse/ARO-27434

## Problem

Scorecard's Token-Permissions check flags workflows that don't declare a top-level `permissions: {}` block. Without it, the default GITHUB_TOKEN gets broader permissions than individual jobs need, violating the principle of least privilege.

## Solution

Add `permissions: {}` at the workflow top level in all 6 files. For workflows that had top-level permission grants, move them down to the specific job that needs them.

## Changes

| File | Change |
|------|--------|
| `pr-validation.yml` | Add top-level `permissions: {}` (job-level `checks: write` already correct) |
| `create-release-stolostron.yml` | Add top-level `permissions: {}` (job-level `contents: write` already correct) |
| `create-release-official.yml` | Add top-level `permissions: {}` (job-level `contents: write` already correct) |
| `create-release-experimental.yml` | Add top-level `permissions: {}` (job-level `contents: write` already correct) |
| `weekly-security-scan.yaml` | Move `contents: read`, `security-events: write`, `issues: write` from top-level to `scan` job |
| `ffwd-branch.yaml` | Move `contents: write` from top-level to `fast-forward` job |

## Testing

- [x] No functional changes — all existing job-level permission grants are preserved
- [x] YAML syntax verified
- [x] Each job retains the exact permissions it had before

Ref: ARO-27434

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated permission scoping configurations in CI/CD workflows to enforce granular access controls, restricting default permissions at the workflow level while granting specific permissions only where necessary at the job level.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->