### PR TITLE
Remove v2/ exclusion from .dockerignore for ART/Konflux builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,6 +13,4 @@ cover-existing.html
 coverage-existing.txt
 report-existing.xml
 testlogs-existing.txt
-v2
-!v2/boilerplate.go.txt
 .git


### PR DESCRIPTION
## Summary

- Removes the `v2` and `!v2/boilerplate.go.txt` entries from `.dockerignore`

## Why

ART/Konflux builds use the **repo root** as the Docker build context (unlike upstream which uses `v2/` directly via `docker build -f Dockerfile.stolostron ../v2`). With `v2` in `.dockerignore`, the build context excludes all `v2/` contents except `boilerplate.go.txt`. This causes `COPY v2/ ./` to silently miss `go.mod`, `go.sum`, and all source files, breaking the build.

## Impact on existing builds

**None.** Both upstream Dockerfiles use `v2/` as the build context directly:
- `v2/Dockerfile` — built from inside `v2/`
- `stolostron/Dockerfile.stolostron` — built via `docker build -f Dockerfile.stolostron ../v2` (per `stolostron/Makefile`)

Since the root-level `.dockerignore` is only consulted when building from the repo root, removing these entries has no effect on existing upstream or downstream builds.


Made with [Cursor](https://cursor.com)