### PR TITLE
fix: resolve PyYAML CVEs (PYSEC-2021-142, PYSEC-2018-49)

### DIFF
--- a/scripts/v2/requirements.txt
+++ b/scripts/v2/requirements.txt
@@ -1,2 +1,2 @@
 deepdiff
-pyyaml
+pyyaml>=6.0.1

--- a/scripts/v2/validate_helm.py
+++ b/scripts/v2/validate_helm.py
@@ -13,14 +13,14 @@ logging.basicConfig(encoding='utf-8', level=logging.INFO)
 def get_yaml(yaml_path):
     with open(yaml_path, "r") as f:
         aso_yaml_file = f.read()
-        aso_yaml = yaml.full_load_all(aso_yaml_file)
+        aso_yaml = yaml.safe_load_all(aso_yaml_file)
         return aso_yaml
 
 def get_helm_templates(helm_dir):
     helm_res = subprocess.check_output(
         f"helm template asov2 {helm_dir} --namespace=azureserviceoperator-system".split(" "))
 
-    helm_resources = yaml.full_load_all(helm_res.decode("utf-8"))
+    helm_resources = yaml.safe_load_all(helm_res.decode("utf-8"))
     return helm_resources
 
 def validate_helm(helm_dir, yaml_path):


### PR DESCRIPTION
## Summary
- Pin `pyyaml>=6.0.1` in `scripts/v2/requirements.txt` to resolve known CVEs
- Replace `yaml.full_load_all` with `yaml.safe_load_all` in `scripts/v2/validate_helm.py` to close the actual vulnerable code path

## Vulnerabilities addressed
| CVE | GHSA | Severity | Description |
|---|---|---|---|
| PYSEC-2021-142 / CVE-2020-14343 | GHSA-8q59-q68h-6hv4 | High | Arbitrary code execution via `full_load` / `FullLoader` |
| PYSEC-2018-49 / CVE-2017-18342 | GHSA-rprw-h62v-c2w7 | Critical (9.8) | Arbitrary code execution via `yaml.load()` on untrusted input |

## Details
`validate_helm.py` uses `yaml.full_load_all()` to parse Kubernetes YAML manifests. These manifests only contain basic types (strings, ints, lists, maps) and never require Python object deserialization, so `safe_load_all` is functionally identical but without the attack surface.

`generate-webhooks-per-group.py` already uses `yaml.safe_load_all` — no change needed there.

Upstream PR: https://github.com/Azure/azure-service-operator/pull/5442

## Test plan
- [ ] Verify `validate_helm.py` still parses helm templates and kustomize output correctly
- [ ] Verify no other scripts depend on `yaml.full_load_all` behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pyyaml dependency to minimum version 6.0.1.

* **Refactor**
  * Enhanced YAML document parsing in Helm validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->