### PR TITLE
fix: enable SCORECARD_TOKEN for branch protection detection

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -49,7 +49,7 @@ jobs:
           # - you want to enable the Branch-Protection check on a *public* repository, or
           # - you are installing Scorecards on a *private* repository
           # To create the PAT, follow the steps in https://github.com/ossf/scorecard-action#authentication-with-fine-grained-pat-optional.
-          # repo_token: ${{ secrets.SCORECARD_TOKEN }}
+          repo_token: ${{ secrets.SCORECARD_TOKEN }}
 
           # Public repositories:
           #   - Publish results to OpenSSF REST API for easy access by consumers


### PR DESCRIPTION
## Summary
- Uncomment `repo_token` in the Scorecard workflow so it can detect branch protection rulesets
- Without admin-scoped token, Scorecard reports Branch-Protection score 0 despite active rulesets on main

## Note
Waiting for org approval of the `SCORECARD_TOKEN` fine-grained PAT.

## Test plan
- [ ] Verify `SCORECARD_TOKEN` secret is created in repo settings
- [ ] Merge and wait for next Scorecard run (scheduled or on push to main)
- [ ] Confirm Branch-Protection alert #4 is resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration to explicitly configure authentication settings for security assessments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->