### PR TITLE
Add .trivyignore for GO-2026-5932 (golang.org/x/crypto/openpgp)

### DIFF
--- a/.github/workflows/weekly-security-scan.yaml
+++ b/.github/workflows/weekly-security-scan.yaml
@@ -32,9 +32,15 @@ jobs:
 
     - name: Check for openpgp imports
       run: |
-        if grep -rq '"golang.org/x/crypto/openpgp' --include="*.go" .; then
+        grep_status=0
+        grep_output=$(grep -rn '"golang.org/x/crypto/openpgp' --include="*.go" . 2>&1) || grep_status=$?
+        if [ "$grep_status" -gt 1 ]; then
+          echo "::error::Failed to scan Go files for openpgp imports."
+          echo "$grep_output" >&2
+          exit 1
+        elif [ "$grep_status" -eq 0 ]; then
           echo "::error::Found import of golang.org/x/crypto/openpgp (unmaintained, GO-2026-5932). Migrate to github.com/ProtonMail/go-crypto/openpgp."
-          grep -rn '"golang.org/x/crypto/openpgp' --include="*.go" .
+          echo "$grep_output"
           exit 1
         fi
 

--- a/.github/workflows/weekly-security-scan.yaml
+++ b/.github/workflows/weekly-security-scan.yaml
@@ -30,6 +30,14 @@ jobs:
       with:
         ref: ${{ matrix.branch }}
 
+    - name: Check for openpgp imports
+      run: |
+        if grep -rq '"golang.org/x/crypto/openpgp' --include="*.go" .; then
+          echo "::error::Found import of golang.org/x/crypto/openpgp (unmaintained, GO-2026-5932). Migrate to github.com/ProtonMail/go-crypto/openpgp."
+          grep -rn '"golang.org/x/crypto/openpgp' --include="*.go" .
+          exit 1
+        fi
+
     - name: Capture scanned commit
       id: scanned-commit
       run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/weekly-security-scan.yaml
+++ b/.github/workflows/weekly-security-scan.yaml
@@ -33,7 +33,7 @@ jobs:
     - name: Check for openpgp imports
       run: |
         grep_status=0
-        grep_output=$(grep -rn '"golang.org/x/crypto/openpgp' --include="*.go" . 2>&1) || grep_status=$?
+        grep_output=$(grep -rn -E '^\s*(import\s+)?([A-Za-z_.][A-Za-z0-9_]*\s+)?"golang\.org/x/crypto/openpgp' --include="*.go" . 2>&1) || grep_status=$?
         if [ "$grep_status" -gt 1 ]; then
           echo "::error::Failed to scan Go files for openpgp imports."
           echo "$grep_output" >&2

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,6 @@
+# GO-2026-5932: golang.org/x/crypto/openpgp is unmaintained and unsafe by design.
+# Severity: UNKNOWN. No fix version available.
+# The openpgp sub-package is not imported anywhere in this codebase.
+# Trivy includes UNKNOWN-severity findings in SARIF output despite the severity
+# filter (CRITICAL,HIGH,MEDIUM,LOW), causing a false-positive workflow failure.
+GO-2026-5932


### PR DESCRIPTION
## Summary

Suppresses advisory `GO-2026-5932` in Trivy scans to fix the [weekly security scan workflow](https://github.com/stolostron/azure-service-operator/actions/runs/29251721679) failing across all branches.

### Root cause

Advisory `GO-2026-5932` flags `golang.org/x/crypto/openpgp` as unmaintained and unsafe by design. Trivy classifies it as **UNKNOWN** severity and includes it in SARIF output even when the severity filter is set to `CRITICAL,HIGH,MEDIUM,LOW`, causing a false-positive exit code 1.

### Why suppression is appropriate

- The `openpgp` sub-package is **not imported anywhere** in this codebase
- There is **no fix version** available for this advisory
- The advisory is `UNKNOWN` severity — it bypasses the workflow severity filter as a Trivy side effect, not a real gap in coverage

Tracked in: https://redhat.atlassian.net/browse/ARO-28416

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the vulnerability scanning exclusions to suppress Trivy findings for GO-2026-5932, citing that `golang.org/x/crypto/openpgp` is unmaintained and unsafe by design with no available fix version.
  * Expanded the exclusion notes to clarify that Trivy may still surface residual `UNKNOWN`-severity results in SARIF even when severities are filtered.
  * Enhanced the weekly security scan to detect deprecated `openpgp` imports early and fail immediately, preventing later scan/report steps from running.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->