### PR TITLE
Add .trivyignore for GO-2026-5932 (golang.org/x/crypto/openpgp)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,6 @@
+# GO-2026-5932: golang.org/x/crypto/openpgp is unmaintained and unsafe by design.
+# Severity: UNKNOWN. No fix version available.
+# The openpgp sub-package is not imported anywhere in this codebase.
+# Trivy includes UNKNOWN-severity findings in SARIF output despite the severity
+# filter (CRITICAL,HIGH,MEDIUM,LOW), causing a false-positive workflow failure.
+GO-2026-5932


### PR DESCRIPTION
## Summary

Suppresses advisory `GO-2026-5932` in Trivy scans to fix the [weekly security scan workflow](https://github.com/stolostron/azure-service-operator/actions/runs/29251721679) failing across all branches.

### Root cause

Advisory `GO-2026-5932` flags `golang.org/x/crypto/openpgp` as unmaintained and unsafe by design. Trivy classifies it as **UNKNOWN** severity and includes it in SARIF output even when the severity filter is set to `CRITICAL,HIGH,MEDIUM,LOW`, causing a false-positive exit code 1.

### Why suppression is appropriate

- The `openpgp` sub-package is **not imported anywhere** in this codebase
- There is **no fix version** available for this advisory
- The advisory is `UNKNOWN` severity — it bypasses the workflow severity filter as a Trivy side effect, not a real gap in coverage

Tracked in: https://redhat.atlassian.net/browse/ARO-28416

🤖 Generated with [Claude Code](https://claude.com/claude-code)