### PR TITLE
fix(scorecard): install binary to /tmp to avoid self-detection (ARO-28423)

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -36,15 +36,17 @@ jobs:
           set -euo pipefail
           SCORECARD_VERSION="v5.5.0"
           EXPECTED_SHA="83b90a05c1540ef1390db1cd5711e5fd04be9c1d8537fb84d39d02092d6a8dff"
-          curl -fsSLO "https://github.com/ossf/scorecard/releases/download/${SCORECARD_VERSION}/scorecard_${SCORECARD_VERSION#v}_linux_amd64.tar.gz"
-          echo "${EXPECTED_SHA}  scorecard_${SCORECARD_VERSION#v}_linux_amd64.tar.gz" | sha256sum -c -
-          tar xzf "scorecard_${SCORECARD_VERSION#v}_linux_amd64.tar.gz" scorecard
-          chmod +x scorecard
+          # Install to /tmp: --local walks the filesystem so a binary in the repo root flags itself.
+          curl -fsSL "https://github.com/ossf/scorecard/releases/download/${SCORECARD_VERSION}/scorecard_${SCORECARD_VERSION#v}_linux_amd64.tar.gz" \
+            -o /tmp/scorecard.tar.gz
+          echo "${EXPECTED_SHA}  /tmp/scorecard.tar.gz" | sha256sum -c -
+          tar xzf /tmp/scorecard.tar.gz -C /tmp scorecard
+          chmod +x /tmp/scorecard
 
       - name: "Run analysis"
         run: |
           set -euo pipefail
-          ./scorecard --local=./ --format=json --show-details > results.json.tmp
+          /tmp/scorecard --local=./ --format=json --show-details > results.json.tmp
           mv results.json.tmp results.json
 
       - name: "Convert JSON to SARIF"


### PR DESCRIPTION
## Summary

- Fix OpenSSF Scorecard Binary-Artifacts score dropping from 10/10 to 9/10 due to the scorecard binary flagging itself during the scan.

JIRA: https://redhat.atlassian.net/browse/ARO-28423

## Problem

The `scorecards.yml` workflow downloaded the scorecard ELF binary into the repository root, then ran `./scorecard --local=./` to scan the source tree.

The Scorecard `--local` client walks the filesystem using `filepath.Walk` (not `git ls-files`) and **does not respect `.gitignore`**. Because the scorecard binary was sitting in the repo root at scan time, the tool detected its own ELF binary as a binary artifact — penalizing the score by 1 point.

## Solution

Install and run the scorecard binary from `/tmp` instead of the repo root, keeping the ELF outside the scanned directory. The sha256 integrity check is updated to reference the new path.

## Changes

- `.github/workflows/scorecards.yml` — download to `/tmp/scorecard.tar.gz`, extract to `/tmp/`, run as `/tmp/scorecard`

## Testing

- [ ] Next scheduled Scorecard run (Tuesday 07:20 UTC) or a push to `main` should report Binary-Artifacts score 10/10

Ref: ARO-28423

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the security analysis workflow by using a verified, pinned Scorecard tool in a temporary location.
  * Preserved existing analysis and reporting behavior, including detailed results and SARIF output.
  * No user-facing product functionality was changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->