### PR TITLE
fix: use repo root as docker build context for devcontainer

### DIFF
--- a/.github/workflows/api-docs-repo.yaml
+++ b/.github/workflows/api-docs-repo.yaml
@@ -73,7 +73,7 @@ jobs:
         # See: https://github.com/moby/moby/issues/41687#issuecomment-733826074 and related issues
         run: |
           docker pull docker.pkg.github.com/azure/azure-service-operator/aso-devcontainer:latest
-          docker build --cache-from docker.pkg.github.com/azure/azure-service-operator/aso-devcontainer:latest --tag devcontainer:latest .devcontainer
+          docker build --cache-from docker.pkg.github.com/azure/azure-service-operator/aso-devcontainer:latest --tag devcontainer:latest -f .devcontainer/Dockerfile .
         env:
           DOCKER_BUILDKIT: 1
 

--- a/.github/workflows/create-release-experimental.yml
+++ b/.github/workflows/create-release-experimental.yml
@@ -39,7 +39,7 @@ jobs:
         # NB: if you update this also update live-validation.yml, pre-release-tests.yaml and create-release-official.yaml
         id: devcontainer
         run: |
-          docker build --tag devcontainer:latest .devcontainer
+          docker build --tag devcontainer:latest -f .devcontainer/Dockerfile .
           mkdir -p $HOME/.docker # in case it doesn't exist
           container_id=$(docker create -w /workspace -v $GITHUB_WORKSPACE:/workspace -v /var/run/docker.sock:/var/run/docker.sock devcontainer:latest)
           docker start "$container_id"

--- a/.github/workflows/create-release-official.yml
+++ b/.github/workflows/create-release-official.yml
@@ -32,7 +32,7 @@ jobs:
         # NB: if you update this also update live-validation.yml, pre-release-tests.yaml and create-release-experimental.yml
         id: devcontainer
         run: |
-          docker build --tag devcontainer:latest .devcontainer
+          docker build --tag devcontainer:latest -f .devcontainer/Dockerfile .
           mkdir -p $HOME/.docker # in case it doesn't exist
           container_id=$(docker create -w /workspace -v $GITHUB_WORKSPACE:/workspace -v /var/run/docker.sock:/var/run/docker.sock devcontainer:latest)
           docker start "$container_id"

--- a/.github/workflows/create-release-stolostron.yml
+++ b/.github/workflows/create-release-stolostron.yml
@@ -29,7 +29,7 @@ jobs:
         # NB: if you update this also update live-validation.yml, pre-release-tests.yaml and create-release-experimental.yml
         id: devcontainer
         run: |
-          docker build --tag devcontainer:latest .devcontainer
+          docker build --tag devcontainer:latest -f .devcontainer/Dockerfile .
           mkdir -p $HOME/.docker # in case it doesn't exist
           container_id=$(docker create -w /workspace -v $GITHUB_WORKSPACE:/workspace -v /var/run/docker.sock:/var/run/docker.sock devcontainer:latest)
           docker start "$container_id"

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -58,7 +58,7 @@ jobs:
         # See: https://github.com/moby/moby/issues/41687#issuecomment-733826074 and related issues
         run: |
           docker pull docker.pkg.github.com/azure/azure-service-operator/aso-devcontainer:latest
-          docker build --cache-from docker.pkg.github.com/azure/azure-service-operator/aso-devcontainer:latest --tag devcontainer:latest .devcontainer
+          docker build --cache-from docker.pkg.github.com/azure/azure-service-operator/aso-devcontainer:latest --tag devcontainer:latest -f .devcontainer/Dockerfile .
         env:
           DOCKER_BUILDKIT: 1
 

--- a/.github/workflows/helm-chart-repo.yaml
+++ b/.github/workflows/helm-chart-repo.yaml
@@ -86,7 +86,7 @@ jobs:
         # See: https://github.com/moby/moby/issues/41687#issuecomment-733826074 and related issues
         run: |
           docker pull docker.pkg.github.com/azure/azure-service-operator/aso-devcontainer:latest
-          docker build --cache-from docker.pkg.github.com/azure/azure-service-operator/aso-devcontainer:latest --tag devcontainer:latest .devcontainer
+          docker build --cache-from docker.pkg.github.com/azure/azure-service-operator/aso-devcontainer:latest --tag devcontainer:latest -f .devcontainer/Dockerfile .
         env:
           DOCKER_BUILDKIT: 1
 

--- a/.github/workflows/live-validation.yml
+++ b/.github/workflows/live-validation.yml
@@ -35,7 +35,7 @@ jobs:
         # NB: if you update this also update pre-release-tests.yaml, create-release-experimental.yml and create-release-official.yaml
         id: devcontainer
         run: |
-          docker build --tag devcontainer:latest .devcontainer
+          docker build --tag devcontainer:latest -f .devcontainer/Dockerfile .
           container_id=$(docker create -w /workspace -v $GITHUB_WORKSPACE:/workspace -v /var/run/docker.sock:/var/run/docker.sock --network=host devcontainer:latest)
           docker start "$container_id"
           echo "container_id=$container_id" >> $GITHUB_ENV

--- a/.github/workflows/pr-validation-docs.yml
+++ b/.github/workflows/pr-validation-docs.yml
@@ -52,7 +52,7 @@ jobs:
         # See: https://github.com/moby/moby/issues/41687#issuecomment-733826074 and related issues
         run: |
           docker pull docker.pkg.github.com/azure/azure-service-operator/aso-devcontainer:latest
-          docker build --cache-from docker.pkg.github.com/azure/azure-service-operator/aso-devcontainer:latest --tag devcontainer:latest .devcontainer
+          docker build --cache-from docker.pkg.github.com/azure/azure-service-operator/aso-devcontainer:latest --tag devcontainer:latest -f .devcontainer/Dockerfile .
         env:
           DOCKER_BUILDKIT: 1
 

--- a/.github/workflows/pre-release-tests.yaml
+++ b/.github/workflows/pre-release-tests.yaml
@@ -35,7 +35,7 @@ jobs:
         # NB: if you update this also update live-validation.yml, create-release-experimental.yml and create-release-official.yaml
         id: devcontainer
         run: |
-          docker build --tag devcontainer:latest .devcontainer
+          docker build --tag devcontainer:latest -f .devcontainer/Dockerfile .
           container_id=$(docker create -w /workspace -v $GITHUB_WORKSPACE:/workspace -v /var/run/docker.sock:/var/run/docker.sock --network=host devcontainer:latest)
           docker start "$container_id"
           echo "container_id=$container_id" >> $GITHUB_ENV

--- a/.github/workflows/scan-controller-image.yaml
+++ b/.github/workflows/scan-controller-image.yaml
@@ -58,7 +58,7 @@ jobs:
         # See: https://github.com/moby/moby/issues/41687#issuecomment-733826074 and related issues
         run: |
           docker pull docker.pkg.github.com/azure/azure-service-operator/aso-devcontainer:latest
-          docker build --cache-from docker.pkg.github.com/azure/azure-service-operator/aso-devcontainer:latest --tag devcontainer:latest .devcontainer
+          docker build --cache-from docker.pkg.github.com/azure/azure-service-operator/aso-devcontainer:latest --tag devcontainer:latest -f .devcontainer/Dockerfile .
         env:
           DOCKER_BUILDKIT: 1
 


### PR DESCRIPTION
## Summary

- Commit e6dc850 (`ARO-25822`) changed `.devcontainer/Dockerfile` to `COPY` files using repo-root-relative paths (e.g. `.devcontainer/install-dependencies.sh`, `v2/go.mod`) and introduced `Dockerfile.dockerignore` with matching paths — both requiring the **repo root** as the Docker build context.
- The PR validation workflows (`pr-validation.yml`, `pr-validation-fork.yml`) were already updated to use the correct form (`-f .devcontainer/Dockerfile .`), but the release and other workflows were not.
- This caused the `create-release-official` workflow to fail on the `v2.13.0-hcpclusters.10` tag push with `"not found"` errors for those files (run [#29428332056](https://github.com/stolostron/azure-service-operator/actions/runs/29428332056)).

**Fix:** replace `docker build ... .devcontainer` with `docker build ... -f .devcontainer/Dockerfile .` in all 10 affected workflows.

## Affected workflows

| File | Status |
|---|---|
| `create-release-official.yml` | fixed (was failing) |
| `create-release-stolostron.yml` | fixed |
| `create-release-experimental.yml` | fixed |
| `live-validation.yml` | fixed |
| `pre-release-tests.yaml` | fixed |
| `deploy-site.yml` | fixed |
| `scan-controller-image.yaml` | fixed |
| `pr-validation-docs.yml` | fixed |
| `api-docs-repo.yaml` | fixed |
| `helm-chart-repo.yaml` | fixed |

## Test plan

- [ ] Re-run the failed workflow after merging to confirm it passes
- [ ] Verify `pr-validation.yml` and `pr-validation-fork.yml` continue to pass (they already used the correct form and are unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)