### PR TITLE
fix: add missing Apply method to clientHelper

### DIFF
--- a/v2/internal/util/kubeclient/kube_client.go
+++ b/v2/internal/util/kubeclient/kube_client.go
@@ -46,6 +46,10 @@ func NewClient(client client.Client) Client {
 	}
 }
 
+func (c *clientHelper) Apply(ctx context.Context, obj runtime.ApplyConfiguration, opts ...client.ApplyOption) error {
+	return c.client.Apply(ctx, obj, opts...)
+}
+
 func (c *clientHelper) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
 	return c.client.Get(ctx, key, obj, opts...)
 }


### PR DESCRIPTION
## Summary

- `asoctl/go.mod` uses controller-runtime **v0.23.3**, which added `Apply` to the `client.Client` interface.
- `v2/go.mod` still uses v0.20.4 (which predates `Apply`), but `asoctl` replaces the v2 module via a local path (`replace github.com/Azure/azure-service-operator/v2 => ../../`).
- When building `asoctl`, Go's MVS selects **v0.23.3** for the entire dependency graph, including the v2 module code. This means `clientHelper` must implement `Apply` to satisfy `client.Client`.
- The build failed with: `*clientHelper does not implement Client (missing method Apply)` ([run #29434431717](https://github.com/stolostron/azure-service-operator/actions/runs/29434431717)).

**Fix:** add a delegating `Apply` method to `clientHelper` — identical to the fix already present in upstream `Azure/azure-service-operator` main.

## Test plan

- [ ] Re-run the release tag workflow after merging to confirm `asoctl:build-linux-amd64` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)