### PR TITLE
fix: add MCE version to ASO User-Agent header (ARO-24154)

### DIFF
--- a/.tekton/azure-service-operator-mce-50-pull-request.yaml
+++ b/.tekton/azure-service-operator-mce-50-pull-request.yaml
@@ -42,6 +42,9 @@ spec:
     value: "true"
   - name: prefetch-input
     value: '[{"type": "gomod", "path": "v2"}]'
+  - name: build-args
+    value:
+    - GIT_COMMIT={{revision}}
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/azure-service-operator-mce-51-pull-request.yaml
+++ b/.tekton/azure-service-operator-mce-51-pull-request.yaml
@@ -42,6 +42,9 @@ spec:
     value: "true"
   - name: prefetch-input
     value: '[{"type": "gomod", "path": "v2"}]'
+  - name: build-args
+    value:
+    - GIT_COMMIT={{revision}}
   pipelineRef:
     resolver: git
     params:

--- a/stolostron/Dockerfile.stolostron
+++ b/stolostron/Dockerfile.stolostron
@@ -11,6 +11,9 @@ WORKDIR /workspace
 
 ENV GOFLAGS="-buildvcs=false"
 
+ARG MCE_VERSION=dev
+ARG GIT_COMMIT=unknown
+
 COPY ./ ./
 
 # Cache deps before building and copying source so that we don't need to re-download as much
@@ -23,7 +26,10 @@ RUN  --mount=type=cache,target=/root/.local/share/golang \
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.local/share/golang \
-    CGO_ENABLED=1 GOOS=linux GOARCH=${ARCH} go build -o ./aso-controller ./cmd/controller/
+    SHORT_COMMIT=$(echo "${GIT_COMMIT}" | cut -c1-7) && \
+    CGO_ENABLED=1 GOOS=linux GOARCH=${ARCH} \
+    go build -ldflags "-X 'github.com/Azure/azure-service-operator/v2/internal/version.BuildVersion=${MCE_VERSION}-${SHORT_COMMIT}'" \
+    -o ./aso-controller ./cmd/controller/
 
 # Copy the aso-controller into a thin image
 FROM registry.access.redhat.com/ubi9/ubi:9.8-1785388874@sha256:aecc1f893388841178ce0276e2f7b087e63e1e4521ec86a96d9c9416c6d419fa

--- a/stolostron/Makefile
+++ b/stolostron/Makefile
@@ -5,4 +5,4 @@ IMG_TAG ?= latest
 IMG ?= ${IMG_REG}/${IMG_REPO}/${IMG_NAME}:${IMG_TAG}
 
 docker-build:
-	docker build -f Dockerfile.stolostron ../v2 -t ${IMG}
+	docker build -f Dockerfile.stolostron --build-arg GIT_COMMIT=$$(git rev-parse --short HEAD 2>/dev/null || echo unknown) ../v2 -t ${IMG}


### PR DESCRIPTION
## Summary
- Set `version.BuildVersion` via ldflags in the stolostron Dockerfile so that ASO ARM requests include the MCE version in the User-Agent header (e.g., `aso-controller/v5.0.0-59235ca`)
- Add `MCE_VERSION` and `GIT_COMMIT` build-args to `stolostron/Dockerfile.stolostron`
- Pass `GIT_COMMIT={{revision}}` in Tekton pipeline `build-args` for mce-50 and mce-51
- Update `stolostron/Makefile` to pass `GIT_COMMIT` for local builds

## Context
During the AROSLSRE-720 incident, ASO hot-looped VNet deletion (~6,740 events in 5 hours). SREs couldn't identify which ASO version was making the ARM calls because the User-Agent was `aso-controller/` (empty version). This fix embeds the MCE version and commit hash into the binary.

Related: [ARO-24154](https://issues.redhat.com/browse/ARO-24154)
Related CAPZ PR: https://github.com/stolostron/cluster-api-provider-azure/pull/399

## Test plan
- [ ] Verify Konflux build passes and injects `MCE_VERSION` from component config
- [ ] Extract binary from built image and confirm `strings aso-controller | grep BuildVersion` shows version
- [ ] Deploy and verify `aso-controller/v5.0.0-<hash>` appears in ARM request User-Agent headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ARO-24154]: https://redhat.atlassian.net/browse/ARO-24154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Build artifacts now include a version identifier combining the release version and a shortened source revision.
  * Container builds pass source revision information automatically, using a fallback when unavailable.
  * Improved build metadata supports clearer artifact identification and traceability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->