### PR TITLE
fix: address security audit findings (FIND-008, FIND-009, FIND-011, FIND-014)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
   ],
   "baseBranchPatterns": [
     "main",
-    "/^backplane-2\\.[0-9]+$/"
+    "/^backplane-[0-9]+\\.[0-9]+$/"
   ],
   "tekton": {
     "includePaths": [
@@ -35,7 +35,7 @@
     {
       "matchBaseBranches": [
         "main",
-        "/^backplane-2\\.[0-9]+$/"
+        "/^backplane-[0-9]+\\.[0-9]+$/"
       ],
       "matchManagers": [
         "tekton"

--- a/stolostron/Dockerfile.stolostron
+++ b/stolostron/Dockerfile.stolostron
@@ -32,7 +32,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     -o ./aso-controller ./cmd/controller/
 
 # Copy the aso-controller into a thin image
-FROM registry.access.redhat.com/ubi9/ubi:9.8-1785388874@sha256:aecc1f893388841178ce0276e2f7b087e63e1e4521ec86a96d9c9416c6d419fa
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1786323074@sha256:57c8151c51445a07e503dab9dc9211dc3cdeac9d45ed81a10954b7d770659b3b
 COPY --from=builder /workspace/aso-controller /aso-controller
 COPY stolostron/crds ./crds
 USER 65532:65532

--- a/v2/config/manager/manager.yaml
+++ b/v2/config/manager/manager.yaml
@@ -2,6 +2,10 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: system
+  labels:
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -79,6 +83,8 @@ spec:
           runAsNonRoot: true
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
           capabilities:
             drop:
               - ALL


### PR DESCRIPTION
## Summary

Addresses four findings from a security audit (HCMSEC-3528):

- **FIND-008** (Low): Add `seccompProfile: RuntimeDefault` to controller container securityContext in `v2/config/manager/manager.yaml`. Without this, the container runs with seccomp `Unconfined` on clusters not enforcing PSA `restricted`, leaving container-escape primitives unmitigated.
- **FIND-009** (Low): Switch Dockerfile runtime image from full `ubi9/ubi` (~210 MB, includes shell, dnf, coreutils) to `ubi9/ubi-minimal` (~100 MB). The full UBI userland enlarges the post-exploitation surface for a static Go binary that needs no userland beyond glibc.
- **FIND-011** (Medium): Fix `renovate.json` `baseBranchPatterns` regex from `^backplane-2\.[0-9]+$` to `^backplane-[0-9]+\.[0-9]+$` so that Renovate/Mintmaker raises dependency-update PRs against `backplane-5.x` release branches (currently only `main` and EOL `backplane-2.x` receive automated CVE-driven bumps). Same fix applied to `matchBaseBranches`.
- **FIND-014** (Low): Add Pod Security Admission labels (`pod-security.kubernetes.io/enforce: restricted`, plus `audit` and `warn`) to the operator Namespace in `v2/config/manager/manager.yaml`. Defence-in-depth: prevents future sidecars or debug containers injected into the namespace from running with elevated privileges.

## Test plan

- [ ] Verify `ubi-minimal` runtime image works with `CGO_ENABLED=1` binary (has glibc)
- [ ] Verify kustomize build still produces valid manifests with PSA labels and seccompProfile
- [ ] Verify Renovate picks up `backplane-5.0` and `backplane-5.1` branches after regex fix
- [ ] Konflux build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)