### PR TITLE
fix: bump github.com/google/cel-go to v0.29.0 (ARO-29061)

### DIFF
--- a/v2/go.mod
+++ b/v2/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/go-logr/logr v1.4.3
 	github.com/go-logr/zapr v1.3.0
 	github.com/go-sql-driver/mysql v1.9.3
-	github.com/google/cel-go v0.28.0
+	github.com/google/cel-go v0.29.0
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/hbollon/go-edlib v1.7.0

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -239,8 +239,8 @@ github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Z
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.1.3 h1:CVpQJjYgC4VbzxeGVHfvZrv1ctoYCAI8vbl07Fcxlyg=
 github.com/google/btree v1.1.3/go.mod h1:qOPhT0dTNdNzV6Z/lhRX0YXUafgPLFUh+gZMl761Gm4=
-github.com/google/cel-go v0.28.0 h1:KjSWstCpz/MN5t4a8gnGJNIYUsJRpdi/r97xWDphIQc=
-github.com/google/cel-go v0.28.0/go.mod h1:X0bD6iVNR8pkROSOoHVdgTkzmRcosof7WQqCD6wcMc8=
+github.com/google/cel-go v0.29.0 h1:fEG+Ja3YRwNOqnQxTyJwoByAUAvTuxUGiro/jhrm4F4=
+github.com/google/cel-go v0.29.0/go.mod h1:X0bD6iVNR8pkROSOoHVdgTkzmRcosof7WQqCD6wcMc8=
 github.com/google/gnostic-models v0.7.0 h1:qwTtogB15McXDaNqTZdzPJRHvaVJlAl+HVQnLmJEJxo=
 github.com/google/gnostic-models v0.7.0/go.mod h1:whL5G0m6dmc5cPxKc5bdKdEN3UjI7OUGxBlw57miDrQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=


### PR DESCRIPTION
## Summary
Bumps `github.com/google/cel-go` from v0.28.0 to v0.29.0 in `v2/go.mod` to clear the Trivy MEDIUM finding reported by the weekly security scan.

## Problem
The [Weekly security scan](https://github.com/stolostron/azure-service-operator/actions/runs/31387617454) failed at the \"Fail if vulnerabilities found\" gate. On `main`, `v2/go.mod` still pinned cel-go v0.28.0, which is affected by GHSA-gcjh-h69q-9w9g (cel-go: JSON private fields exposed via NativeTypes). grpc (v1.82.1) and asoctl's cel-go (v0.29.0) were already on fixed versions.

## Solution
`go get github.com/google/cel-go@v0.29.0 && go mod tidy` in the `v2` module.

## Changes
- `v2/go.mod`, `v2/go.sum`: cel-go v0.28.0 -> v0.29.0

## Testing
- [x] `internal/util/cel` (cel-go consumer) builds and vets clean against v0.29.0
- [x] `go mod verify` passes

JIRA: https://redhat.atlassian.net/browse/ARO-29061

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the CEL evaluation dependency to version 0.29.0.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->