### PR TITLE
Trigger mce-50 (5.0) build on release-2.18 pull requests

### DIFF
--- a/.tekton/azure-service-operator-mce-50-pull-request.yaml
+++ b/.tekton/azure-service-operator-mce-50-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && ( target_branch == "backplane-5.0" || target_branch == "main" )
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && ( target_branch == "backplane-5.0" || target_branch == "release-2.18" )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: release-mce-50

--- a/v2/.dockerignore
+++ b/v2/.dockerignore
@@ -1,8 +1,21 @@
 **
 
-# Ignore everything except below
+# Ignore everything except the Go module files, Go sources and the CRD bundles.
+#
+# We re-include whole source directories (rather than only "!**/*.go") because
+# buildah / the classic Docker builder do NOT descend into a directory that is
+# excluded by "**" in order to re-apply a nested negation like "!**/*.go"
+# (BuildKit does, which is why the upstream whitelist works with `docker buildx`
+# but breaks the Konflux buildah build). Listing the source directories keeps the
+# huge specs/azure-rest-api-specs submodule out of the build context while still
+# shipping all of the Go sources needed by `go build ./cmd/controller/`.
 !/go.mod
 !/go.sum
-!**/*.go
+!/api
+!/cmd
+!/internal
+!/pkg
+!/test
+!/tools
 !/out/crds
 !/stolostron/crds


### PR DESCRIPTION
## What

Point the `mce-50` (5.0) pull-request Tekton pipeline at `release-2.18` instead of `main`:

```
- event == "pull_request" && ( target_branch == "backplane-5.0" || target_branch == "main" )
+ event == "pull_request" && ( target_branch == "backplane-5.0" || target_branch == "release-2.18" )
```

## Why

Branch → build mapping (fast-forward sync):
- `main` → `backplane-5.1` (5.1 line)
- `release-2.18` → `backplane-5.0` (5.0 line)

`release-2.18` is the 5.0 development line, so PRs against it must trigger the **mce-50 (5.0)** Konflux build. The pipeline still referenced `main` (the 5.1 line), so:
- PRs against `release-2.18` never triggered a 5.0 build.
- PRs against `main` spuriously triggered the 5.0 build.

The `mce-50-push` condition (`backplane-5.0`) and the `5.0.x` image tags are already correct — only the pull-request trigger needed fixing.

## Companion change

On `main`, mce-50 is kept as an inert placeholder and main PRs are gated on mce-51/backplane-5.1 — see stolostron/azure-service-operator#471.

## Follow-up (not in this PR)

`.github/workflows/pr-capi-tests.yaml` on this branch does not trigger on `release-2.18` PRs. If 5.0 PRs should also run the capi-tests integration gate against `backplane-5.0`, that workflow needs a `release-2.18` trigger + mapping — happy to add it if wanted.