### PR TITLE
Fix azure-rest-api-specs submodule pin for release-2.19 (Konflux build)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "azure-rest-api-specs"]
 	path = v2/specs/azure-rest-api-specs
-	url = https://github.com/Azure/azure-rest-api-specs
+	url = https://github.com/marek-veber/azure-rest-api-specs

--- a/v2/.dockerignore
+++ b/v2/.dockerignore
@@ -1,8 +1,21 @@
 **
 
-# Ignore everything except below
+# Ignore everything except the Go module files, Go sources and the CRD bundles.
+#
+# We re-include whole source directories (rather than only "!**/*.go") because
+# buildah / the classic Docker builder do NOT descend into a directory that is
+# excluded by "**" in order to re-apply a nested negation like "!**/*.go"
+# (BuildKit does, which is why the upstream whitelist works with `docker buildx`
+# but breaks the Konflux buildah build). Listing the source directories keeps the
+# huge specs/azure-rest-api-specs submodule out of the build context while still
+# shipping all of the Go sources needed by `go build ./cmd/controller/`.
 !/go.mod
 !/go.sum
-!**/*.go
+!/api
+!/cmd
+!/internal
+!/pkg
+!/test
+!/tools
 !/out/crds
 !/stolostron/crds


### PR DESCRIPTION
release-2.19 pinned spec commit `a28c3b88` while `.gitmodules` pointed at `Azure/azure-rest-api-specs`, where that commit is on no ref. A fresh clone (as Konflux does) therefore fails `git submodule update` with **exit 128** (GitHub refuses fetch-by-SHA for commits unreachable from a ref).

This PR:
- Repoints the submodule URL to `https://github.com/marek-veber/azure-rest-api-specs`.
- Pins `581214507` — ASO `v2.19.0` spec base `9840b830` + the ARO-HCP `hcpopenshiftclusters` specs, reachable via branch `RedHatOpenShift-hcpclusters-2026-06-30-v2.19.0`. Its tree is identical to the previously-pinned `a28c3b88`; only the lineage/reachability changes.

Note: this ties the build to a personal fork. If preferred, the `RedHatOpenShift-hcpclusters-*` branches can be moved to a stolostron-owned fork and `.gitmodules` repointed.