### PR TITLE
ci: run CodeQL on release-*/backplane-2* PRs (fix phantom required check)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,11 +13,11 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ main, "backplane-2*" ]
+    branches: [ main, "release-*", "backplane-2*" ]
   pull_request:
-    branches: [ main, "backplane-2*" ]
+    branches: [ main, "release-*", "backplane-2*" ]
   merge_group:
-    branches: [ main, "backplane-2*" ]
+    branches: [ main, "release-*", "backplane-2*" ]
   schedule:
     - cron: '31 1 * * 3'
 


### PR DESCRIPTION
## What

Add `release-*` (and `backplane-2*` where missing) to the branch filters in `.github/workflows/codeql.yml` so the **CodeQL** workflow actually runs on PRs into this branch.

## Why

The `main-branch-protection` ruleset marks **`Analyze (go)`** (the CodeQL job) as a *required* status check on `main`, `backplane-2.17`, `backplane-2.11`, and `release-*`. But `codeql.yml` only triggered on `main` (and `backplane-2*` on release branches), so PRs into release/backplane branches waited forever on a required check that never ran — leaving them permanently **BLOCKED** (e.g. #472).

This makes the required check produce a real status instead of a phantom pending one.

> [!NOTE]
> Bootstrap caveat: this PR is itself gated by the not-yet-fixed check on its base branch, so it likely needs an admin merge/bypass. Once merged, subsequent PRs into this branch run CodeQL normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)