### PR TITLE
docs: add AGENTS.md index and docs/DOWNSTREAM.md (ARO-29246)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,40 @@
+# Agent context index — stolostron/azure-service-operator
+
+Entry point for AI coding agents (and new humans) working in this repository.
+
+This file is a **table of contents**, not a manual. Read the linked document
+for detail before making changes. For fork-specific context (branch model,
+upstream sync, build pipelines) start with
+[`docs/DOWNSTREAM.md`](docs/DOWNSTREAM.md).
+
+## What this repository is
+
+`stolostron/azure-service-operator` is a downstream fork of
+[`Azure/azure-service-operator`](https://github.com/Azure/azure-service-operator)
+(ASO). It packages the ASO controller for **Azure Red Hat OpenShift Hosted
+Control Planes (ARO-HCP)** and ships it as part of **multicluster engine
+(MCE) / backplane** via [Konflux](https://konflux-ci.dev/) builds.
+
+## Where to start
+
+| Document | What it covers |
+|----------|----------------|
+| [README.md](README.md) | Project overview. |
+| [v2/README.md](v2/README.md) | ASO v2 installation, usage, and supported resources. |
+| [CONTRIBUTING.md](CONTRIBUTING.md) | Upstream contribution workflow. |
+| [docs/DOWNSTREAM.md](docs/DOWNSTREAM.md) | **Fork-specific context** — branch model, upstream sync, Konflux pipelines, what lives in `stolostron/`. Read this before opening a PR. |
+| [docs/branch-sync-policy.md](docs/branch-sync-policy.md) | Authoritative branch-to-source mapping and protection rules. |
+| [SECURITY.md](SECURITY.md) | Vulnerability reporting. |
+| [SUPPORT.md](SUPPORT.md) | Support channels. |
+
+## Key directories
+
+| Path | Purpose |
+|------|---------|
+| `v2/` | All Go source (controller, CRDs, API types, tests). |
+| `v2/api/` | Generated CRD API types. |
+| `v2/pkg/` | Controller implementation packages. |
+| `stolostron/` | Downstream-only build artifacts (`Dockerfile.stolostron`, `Makefile`). |
+| `.tekton/` | Konflux `PipelineRun` definitions for MCE releases. |
+| `.github/workflows/` | CI workflows including upstream sync and branch fast-forwards. |
+| `docs/` | Human-readable documentation and policies. |

--- a/docs/DOWNSTREAM.md
+++ b/docs/DOWNSTREAM.md
@@ -1,0 +1,73 @@
+# Downstream context (stolostron / ARO-HCP)
+
+Entry point for the fork-specific layer of this repository. This file covers
+only what is **specific to the stolostron fork** — it does not duplicate
+upstream documentation.
+
+> **This is a downstream fork.** The engineering source of truth for ASO
+> architecture, controller patterns, CRD generation, and build/test commands
+> lives upstream in [`Azure/azure-service-operator`](https://github.com/Azure/azure-service-operator).
+> Start with [`v2/README.md`](../v2/README.md) and [`CONTRIBUTING.md`](../CONTRIBUTING.md).
+> This page adds only the stolostron/ARO-HCP layer on top.
+
+## What this fork is
+
+`stolostron/azure-service-operator` packages the ASO controller for
+**Azure Red Hat OpenShift Hosted Control Planes (ARO-HCP)** and ships it as
+part of **multicluster engine (MCE) / backplane** via
+[Konflux](https://konflux-ci.dev/) builds.
+
+The Go module path stays `github.com/Azure/azure-service-operator/v2` — this
+fork does not rename the module.
+
+## How it differs from upstream
+
+The Go source in `v2/` is kept as close to upstream as possible. The
+downstream-only pieces are the ARO-HCP API version pin, the branch model, the
+upstream sync workflow, and the Konflux build configuration.
+
+| Concern | Where it lives | Notes |
+|---------|----------------|-------|
+| Upstream sync | [`.github/workflows/sync-upstream-main.yaml`](../.github/workflows/sync-upstream-main.yaml) | Weekly (Mon 06:00 UTC) + manual dispatch. Cherry-picks new upstream commits onto a `sync/upstream-main` branch and opens a draft PR. Go module conflicts auto-resolved; other conflicts stop the run and report resolution steps. |
+| Branch fast-forward | [`.github/workflows/ffwd-branch.yaml`](../.github/workflows/ffwd-branch.yaml) | Every push to `main` is fast-forwarded into `backplane-5.1`. One-directional — direct PRs to `backplane-5.*` are rejected. |
+| Downstream build | [`stolostron/Dockerfile.stolostron`](../stolostron/Dockerfile.stolostron) | Red Hat UBI9-based image for MCE packaging. Built by Konflux. |
+| Konflux pipelines | [`.tekton/`](../.tekton) | Tekton `PipelineRun` definitions for MCE releases, split into `-pull-request` and `-push` variants. |
+| Branch policy | [`docs/branch-sync-policy.md`](branch-sync-policy.md) | Authoritative branch-to-source mapping and protection rules. |
+
+## Branch model
+
+The authoritative source is [`docs/branch-sync-policy.md`](branch-sync-policy.md).
+Summary:
+
+| Branch | Source | Sync mechanism |
+|--------|--------|----------------|
+| `main` | `Azure/main` + ARO-HCP customizations | Weekly cherry-pick sync via `sync-upstream-main.yaml` (PR-based, not fast-forward) |
+| `backplane-5.1` | `main` | FFWD-only via `ffwd-branch.yaml` on every push to `main` |
+| `backplane-5.0` | `release-2.18` | FFWD-only via `ffwd-release-2.18.yaml` |
+| `release-2.18`, `release-2.19` | upstream release branches + ARO-HCP | Manual, security updates only |
+| `backplane-2.17`, `backplane-2.11` | — | Manual, security findings only |
+
+## Working with the fork
+
+- **All PRs target `main`.** Changes flow to `backplane-5.1` automatically via
+  the fast-forward workflow. Never open a PR directly against a `backplane-*`
+  branch — it will be rejected.
+- **Keep changes upstream-friendly.** Prefer contributing fixes upstream and
+  letting them flow down via the sync. Downstream-only patches make every future
+  sync harder to merge.
+- **Upstream sync conflicts.** When the sync workflow stops at a conflict, it
+  emits a GitHub Actions warning and a step summary with copy-pasteable
+  resolution steps. Resolve on the `sync/upstream-main` branch and push to
+  unblock.
+- **Do not edit upstream-tracked content to add downstream notes.** Put
+  downstream-specific context in this file instead.
+
+## Start here
+
+| Document | What it covers |
+|----------|----------------|
+| [AGENTS.md](../AGENTS.md) | Repository index for AI agents — all key docs and directories. |
+| [v2/README.md](../v2/README.md) | ASO v2 — what it is, installation, supported resources. |
+| [CONTRIBUTING.md](../CONTRIBUTING.md) | Upstream contribution workflow. |
+| [docs/branch-sync-policy.md](branch-sync-policy.md) | Authoritative branch protection and sync rules. |
+| [SECURITY.md](../SECURITY.md) | Vulnerability reporting. |

--- a/docs/DOWNSTREAM.md
+++ b/docs/DOWNSTREAM.md
@@ -28,7 +28,7 @@ upstream sync workflow, and the Konflux build configuration.
 
 | Concern | Where it lives | Notes |
 |---------|----------------|-------|
-| Upstream sync | [`.github/workflows/sync-upstream-main.yaml`](../.github/workflows/sync-upstream-main.yaml) | Weekly (Mon 06:00 UTC) + manual dispatch. Cherry-picks new upstream commits onto a `sync/upstream-main` branch and opens a draft PR. Go module conflicts auto-resolved; other conflicts stop the run and report resolution steps. |
+| Upstream sync | [`.github/workflows/sync-upstream-main.yaml`](../.github/workflows/sync-upstream-main.yaml) | Weekly (Mon 06:00 UTC) + manual dispatch. Merges `upstream/main` into a `sync/upstream-main` branch and opens a regular PR. On any conflict the job fails; resolve the merge manually on `sync/upstream-main` and push to unblock. |
 | Branch fast-forward | [`.github/workflows/ffwd-branch.yaml`](../.github/workflows/ffwd-branch.yaml) | Every push to `main` is fast-forwarded into `backplane-5.1`. One-directional — direct PRs to `backplane-5.*` are rejected. |
 | Downstream build | [`stolostron/Dockerfile.stolostron`](../stolostron/Dockerfile.stolostron) | Red Hat UBI9-based image for MCE packaging. Built by Konflux. |
 | Konflux pipelines | [`.tekton/`](../.tekton) | Tekton `PipelineRun` definitions for MCE releases, split into `-pull-request` and `-push` variants. |
@@ -41,7 +41,7 @@ Summary:
 
 | Branch | Source | Sync mechanism |
 |--------|--------|----------------|
-| `main` | `Azure/main` + ARO-HCP customizations | Weekly cherry-pick sync via `sync-upstream-main.yaml` (PR-based, not fast-forward) |
+| `main` | `Azure/main` + ARO-HCP customizations | Weekly merge-based sync via `sync-upstream-main.yaml` (PR-based, not fast-forward) |
 | `backplane-5.1` | `main` | FFWD-only via `ffwd-branch.yaml` on every push to `main` |
 | `backplane-5.0` | `release-2.18` | FFWD-only via `ffwd-release-2.18.yaml` |
 | `release-2.18`, `release-2.19` | upstream release branches + ARO-HCP | Manual, security updates only |
@@ -55,10 +55,9 @@ Summary:
 - **Keep changes upstream-friendly.** Prefer contributing fixes upstream and
   letting them flow down via the sync. Downstream-only patches make every future
   sync harder to merge.
-- **Upstream sync conflicts.** When the sync workflow stops at a conflict, it
-  emits a GitHub Actions warning and a step summary with copy-pasteable
-  resolution steps. Resolve on the `sync/upstream-main` branch and push to
-  unblock.
+- **Upstream sync conflicts.** When the sync workflow fails on a conflict, it
+  emits an error in the Actions log. Resolve the merge manually on the
+  `sync/upstream-main` branch and push to unblock.
 - **Do not edit upstream-tracked content to add downstream notes.** Put
   downstream-specific context in this file instead.
 

--- a/docs/DOWNSTREAM.md
+++ b/docs/DOWNSTREAM.md
@@ -43,7 +43,7 @@ Summary:
 |--------|--------|----------------|
 | `main` | `Azure/main` + ARO-HCP customizations | Weekly merge-based sync via `sync-upstream-main.yaml` (PR-based, not fast-forward) |
 | `backplane-5.1` | `main` | FFWD-only via `ffwd-branch.yaml` on every push to `main` |
-| `backplane-5.0` | `release-2.18` | FFWD-only via `ffwd-release-2.18.yaml` |
+| `backplane-5.0` | `release-2.18` | Manual (no automated sync) |
 | `release-2.18`, `release-2.19` | upstream release branches + ARO-HCP | Manual, security updates only |
 | `backplane-2.17`, `backplane-2.11` | — | Manual, security findings only |
 


### PR DESCRIPTION
## Description

Contextification Phase 2 ([ARO-29087](https://redhat.atlassian.net/browse/ARO-29087)) asks each CAPZ downstream repo to make its prescriptive context discoverable to people and AI agents.

`stolostron/azure-service-operator` carries no upstream `AGENTS.md`, so this PR adds two files rather than overwriting any upstream-tracked content:

- **`AGENTS.md`** — a thin table-of-contents index pointing at the authoritative docs (`v2/README.md`, `CONTRIBUTING.md`, `docs/branch-sync-policy.md`) and key directories (`v2/`, `stolostron/`, `.tekton/`).
- **`docs/DOWNSTREAM.md`** — fork-specific context that does not belong in any upstream-tracked file: branch model, upstream sync workflow, Konflux build pipelines, and PR targeting rules.

JIRA: https://redhat.atlassian.net/browse/ARO-29246

## Changes Made

- Add `AGENTS.md` — repository index for AI agents and new contributors.
- Add `docs/DOWNSTREAM.md` — stolostron/ARO-HCP fork context (branch model, sync, Konflux, working conventions).

## Files NOT changed (deliberately)

`README.md`, `CONTRIBUTING.md`, `SECURITY.md`, `SUPPORT.md` — all upstream-tracked; left untouched to avoid recurring merge conflicts during upstream sync.

## Additional Notes

Docs-only change; no Go code, tests, or upstream files affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ARO-29087]: https://redhat.atlassian.net/browse/ARO-29087?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ