### PR TITLE
add backplane-5.2 to ffwd target branches

### DIFF
--- a/.github/workflows/ffwd-branch.yaml
+++ b/.github/workflows/ffwd-branch.yaml
@@ -21,7 +21,7 @@ jobs:
     permissions:
       contents: write
     env:
-      TARGET_BRANCHES: backplane-5.1
+      TARGET_BRANCHES: backplane-5.1 backplane-5.2
 
     steps:
       - name: Checkout repo


### PR DESCRIPTION
## Summary
- Adds `backplane-5.2` to the fast-forward target branches so pushes to `main` are automatically synced to `backplane-5.2` alongside `backplane-5.1`.

## Test plan
- [ ] Verify the workflow triggers on push to main
- [ ] Verify backplane-5.2 branch receives the fast-forward merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)