### PR TITLE
fix: hcp_open_shift_cluster_extension.go: import 20260630preview api

### DIFF
--- a/v2/api/redhatopenshift/customizations/hcp_open_shift_cluster_extension.go
+++ b/v2/api/redhatopenshift/customizations/hcp_open_shift_cluster_extension.go
@@ -9,7 +9,7 @@ import (
 
 	. "github.com/Azure/azure-service-operator/v2/internal/logging"
 
-	armstorage "github.com/Azure/ARO-HCP/test/sdk/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
+	armhcp20260630preview "github.com/Azure/ARO-HCP/test/sdk/v20260630preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/go-logr/logr"
 	"github.com/rotisserie/eris"
@@ -104,8 +104,8 @@ func (ext *HcpOpenShiftClusterExtension) ExportKubernetesSecrets(
 	subscription := id.SubscriptionID
 	// Using armClient.ClientOptions() here ensures we share the same HTTP connection, so this is not opening a new
 	// connection each time through
-	var clusterClient *armstorage.HcpOpenShiftClustersClient
-	clusterClient, err = armstorage.NewHcpOpenShiftClustersClient(subscription, armClient.Creds(), armClient.ClientOptions())
+	var clusterClient *armhcp20260630preview.HcpOpenShiftClustersClient
+	clusterClient, err = armhcp20260630preview.NewHcpOpenShiftClustersClient(subscription, armClient.Creds(), armClient.ClientOptions())
 	if err != nil {
 		return nil, eris.Wrapf(err, "failed to create new NewOpenShiftClustersClient")
 	}
@@ -113,7 +113,7 @@ func (ext *HcpOpenShiftClusterExtension) ExportKubernetesSecrets(
 	var adminCredentials string
 	if requestedSecrets.Contains(adminCredentialsKey) {
 		log.V(Debug).Info("Starting BeginRequestAdminCredential")
-		var poller *runtime.Poller[armstorage.HcpOpenShiftClustersClientRequestAdminCredentialResponse]
+		var poller *runtime.Poller[armhcp20260630preview.HcpOpenShiftClustersClientRequestAdminCredentialResponse]
 		poller, err = clusterClient.BeginRequestAdminCredential(ctx, id.ResourceGroupName, typedObj.AzureName(), nil)
 		if err != nil {
 			return nil, eris.Wrapf(err, "failed creating admin credentials")

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -3,7 +3,6 @@ module github.com/Azure/azure-service-operator/v2
 go 1.26.0
 
 require (
-	github.com/Azure/ARO-HCP/test/sdk/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp v0.0.0-20260709163751-8c7d6f781c48
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.22.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.14.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/apimanagement/armapimanagement/v2 v2.1.0
@@ -162,6 +161,8 @@ require (
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.3 // indirect
 )
+
+require github.com/Azure/ARO-HCP/test/sdk/v20260630preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp v0.0.0-20260827105250-f9c0941bedcc
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -41,8 +41,8 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 filippo.io/edwards25519 v1.2.0 h1:crnVqOiS4jqYleHd9vaKZ+HKtHfllngJIiOpNpoJsjo=
 filippo.io/edwards25519 v1.2.0/go.mod h1:xzAOLCNug/yB62zG1bQ8uziwrIqIuxhctzJT18Q77mc=
-github.com/Azure/ARO-HCP/test/sdk/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp v0.0.0-20260709163751-8c7d6f781c48 h1:1POU2baKP58zyf52FdDZxcnRcjncKLG+4rkOcv8eAY0=
-github.com/Azure/ARO-HCP/test/sdk/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp v0.0.0-20260709163751-8c7d6f781c48/go.mod h1:fivuGYZnFzjBOUl3UbGblNtVp7SYfoDrl04rJwNvE50=
+github.com/Azure/ARO-HCP/test/sdk/v20260630preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp v0.0.0-20260827105250-f9c0941bedcc h1:1q0SO6KutdG6U8ULNrekcKUUhXFBcFQBBx3aSv2R2is=
+github.com/Azure/ARO-HCP/test/sdk/v20260630preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp v0.0.0-20260827105250-f9c0941bedcc/go.mod h1:0g5JwVeLX4WIl2FlXVvhJkuQc+bdSFxQSRvFiOI4Ljg=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.22.0 h1:aokoqcHvaGjiM3VpjKDfMMnF/8epJ+Q1HLJ7CudztqE=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.22.0/go.mod h1:/WYEx9pcM9Y+Dd/APJaNlSvVSvzl54rrMdZT5+Oi2LM=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.14.0 h1:CU4+EJeJi3TKYWEcYuSdWsjzw0nVsK/H0MSQOiPcymU=


### PR DESCRIPTION
## What this PR does

This PR replaces the import of `github.com/Azure/ARO-HCP/test/sdk/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp` in ` hcp_open_shift_cluster_extension.go` with the import of  `20260630preview`

`github.com/Azure/ARO-HCP/test/sdk/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp` should not be used, as it is just an older version of the `20241223preview` API, which is to be removed in near future.

<!--  

Here are some tips:

If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. 
Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.

Closes #[issue number]
-->

<!--
### Special notes

_If there's anything complex or unusual about this PR that would help us review it, let us know here. Otherwise delete this section._
-->

## How does this PR make you feel?

![gif](https://giphy.com/)

## Checklist

<!--
_Delete any that don't apply. For completed items, change [ ] to [x]._
-->

- [ ] this PR contains documentation
- [ ] this PR contains tests
- [ ] this PR contains YAML Samples
