### PR TITLE
ACM-41554: switch Dockerfile.stolostron to PQC-enabled base images (release-2.18)

### DIFF
--- a/stolostron/Dockerfile.stolostron
+++ b/stolostron/Dockerfile.stolostron
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:9.8-1787080706@sha256:71e89a1a51ab32cc30634d89ee4dc8ea40ad9991057fa1eae3b1af32bc7db73f AS toolchain
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 AS toolchain
 
 # Run this with docker build --build_arg $(go env GOPROXY) to override the goproxy
 ARG goproxy=https://proxy.golang.org
@@ -32,7 +32,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     -o ./aso-controller ./cmd/controller/
 
 # Copy the aso-controller into a thin image
-FROM registry.access.redhat.com/ubi9/ubi:9.8-1786985871@sha256:5426a8f45e80a07168a30ea24d84f266094b3756624a5508cc53927e6ee39e09
+FROM registry.redhat.io/ubi9/ubi-minimal-pqc:9.8-1787695851
 COPY --from=builder /workspace/aso-controller /aso-controller
 COPY stolostron/crds ./crds
 USER 65532:65532


### PR DESCRIPTION
## Summary

- Switch both build and runtime base images to PQC-enabled variants for post-quantum cryptography support (OCPSTRAT-3113)
- Build: `brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26`
- Runtime: `registry.redhat.io/ubi9/ubi-minimal-pqc:9.8-1787695851`
- Aligns with the CAPZ Dockerfile (`cluster-api-provider-azure/stolostron/Dockerfile.stolostron`)
- Backport of the same change to release-2.18

Jira: https://redhat.atlassian.net/browse/ACM-41554

## Test plan

- [ ] Verify Konflux build succeeds with the new base images
- [ ] Verify the built image starts correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)