### PR TITLE
docs: fix branch-sync-policy drift (ARO-29174)

### DIFF
--- a/docs/branch-sync-policy.md
+++ b/docs/branch-sync-policy.md
@@ -13,7 +13,8 @@ branch reorganization in ARO-27857).
 |---|---|---|---|
 | `main` | upstream `Azure/main` + ARO-HCP (2026-06-30-preview) customizations | Periodic **merge** from `Azure/main` via [`sync-upstream-main.yaml`](../.github/workflows/sync-upstream-main.yaml) (opens a PR — not a fast-forward, because `main` carries ARO-HCP customizations) | Open for PRs (default branch) |
 | `backplane-5.1` | `stolostron/main` | **FFWD only** from `main` via [`ffwd-branch.yaml`](../.github/workflows/ffwd-branch.yaml) | No direct PRs (blocked by [`protect-backplane-branches.yaml`](../.github/workflows/protect-backplane-branches.yaml) + ruleset) |
-| `backplane-5.0` | `stolostron/release-2.18` | **FFWD only, one-directional** from `release-2.18` via [`ffwd-release-2.18.yaml`](../.github/workflows/ffwd-release-2.18.yaml) | No direct PRs (blocked by `protect-backplane-branches.yaml` + ruleset) |
+| `backplane-5.2` | `stolostron/main` | **FFWD only** from `main` via [`ffwd-branch.yaml`](../.github/workflows/ffwd-branch.yaml) (the same workflow fast-forwards `main` into both `backplane-5.1` and `backplane-5.2`) | No direct PRs (blocked by [`protect-backplane-branches.yaml`](../.github/workflows/protect-backplane-branches.yaml) + ruleset) |
+| `backplane-5.0` | `stolostron/release-2.18` | **FFWD only, one-directional** from `release-2.18` via [`ffwd-branch.yaml` (on `release-2.18`)](https://github.com/stolostron/azure-service-operator/blob/release-2.18/.github/workflows/ffwd-branch.yaml) | No direct PRs (blocked by `protect-backplane-branches.yaml` + ruleset) |
 | `release-2.19` | upstream v2.19 + ARO-HCP | Manual, security updates only | Immutable except security updates |
 | `release-2.18` | upstream v2.18 + ARO-HCP | Manual, security updates only (also feeds `backplane-5.0`) | Immutable except security updates |
 | `release-2.13` | upstream v2.13 + ARO-HCP (**former `main`**) | Manual, security updates only | Immutable except security findings |
@@ -26,9 +27,9 @@ branch reorganization in ARO-27857).
   runs weekly (and on demand). Because `main` carries ARO-HCP customizations, it
   performs a **merge** on a `sync/upstream-main` branch and opens a PR for review.
   Conflicts fail the job so they are resolved manually. Nothing is force-pushed to `main`.
-- **`main` → `backplane-5.1`** — [`ffwd-branch.yaml`](../.github/workflows/ffwd-branch.yaml)
-  fast-forwards every push to `main` into `backplane-5.1`. One-directional.
-- **`release-2.18` → `backplane-5.0`** — [`ffwd-release-2.18.yaml`](../.github/workflows/ffwd-release-2.18.yaml)
+- **`main` → `backplane-5.1`, `backplane-5.2`** — [`ffwd-branch.yaml`](../.github/workflows/ffwd-branch.yaml)
+  fast-forwards every push to `main` into both `backplane-5.1` and `backplane-5.2`. One-directional.
+- **`release-2.18` → `backplane-5.0`** — [`ffwd-branch.yaml` (on the `release-2.18` branch)](https://github.com/stolostron/azure-service-operator/blob/release-2.18/.github/workflows/ffwd-branch.yaml)
   fast-forwards every push to `release-2.18` into `backplane-5.0`. One-directional.
 
 Fast-forward is deliberate: the `backplane-*` targets must never diverge from
@@ -42,13 +43,20 @@ required posture:
 
 | Branch(es) | Ruleset enforcement |
 |---|---|
-| `backplane-5.0`, `backplane-5.1` | Non-fast-forward blocked, deletion blocked; updates only via the FFWD bots. Direct PRs rejected by `protect-backplane-branches.yaml`. |
+| `backplane-5.0`, `backplane-5.1`, `backplane-5.2` | Non-fast-forward blocked, deletion blocked; updates only via the FFWD bots. Direct PRs rejected by `protect-backplane-branches.yaml`. |
 | `release-2.13`, `backplane-2.17`, `backplane-2.11` | Immutable: no direct pushes, no deletion, no force-push. Changes only for security findings, via reviewed PR. |
 | `release-2.18`, `release-2.19` | Protected: no force-push, no deletion. Security updates only, via reviewed PR. |
 | `main` | Default protections (PR review + status checks); receives upstream via the sync PR. |
 
 > The mapping table above is authoritative. If a ruleset and this table ever
 > disagree, update whichever is wrong so they match.
+
+> **Gap to reconcile.** The live `backplane-branches-lockdown` ruleset currently
+> includes only `backplane-5.0` and `backplane-5.1`; `backplane-5.2` is not yet a
+> member. Per the rule above, add `refs/heads/backplane-5.2` to that ruleset so its
+> enforcement matches this table. Until then, `backplane-5.2` is protected from
+> direct PRs by `protect-backplane-branches.yaml` but not from force-push/deletion
+> at the ruleset level.
 
 > **Bot bypass required.** The FFWD and sync workflows push with the Actions
 > `GITHUB_TOKEN`. For those pushes to succeed against the protected
@@ -101,11 +109,16 @@ customizations were silently reverted to their upstream form. This audit compare
   Renovate. Restored to `updates: []`.
 - **Konflux / Tekton** — old `main` carried `.tekton` pipelines for `mce-217`,
   `mce-50`, and `mce-51`. Pipelines-as-Code resolves `.tekton` files by cel
-  expression, and only files whose expression includes `target_branch == "main"`
-  need to live on `main`: `mce-51-pull-request` (present ✅) and
-  `mce-50-pull-request` (**dropped in the re-seed**). The `mce-50` pipelines are
-  restored by PR #471. `mce-217` and all `-push` pipelines target their own
-  backplane branches and correctly do not live on `main`.
+  expression, so a pipeline only needs to live on the branches its expression
+  matches. The pull-request pipelines whose expression includes
+  `target_branch == "main"` live on `main`: `mce-51-pull-request` and
+  `mce-52-pull-request` (both present ✅). `mce-50` maps to `backplane-5.0`, which
+  is fed from `release-2.18`, so its pull-request pipeline correctly lives on
+  `release-2.18` (cel: `target_branch == "backplane-5.0" || target_branch ==
+  "release-2.18"`) rather than on `main`; it was added there by PR #472 (PR #471,
+  which had targeted `main`, was closed unmerged and superseded). `mce-217`
+  likewise lives on `release-2.18`, and all `-push` pipelines target their own
+  branches; none of these need to live on `main`.
 
 Branch rulesets and protection are repository-level settings (not files), so they
 are reapplied via the admin API per the table above rather than carried by the

--- a/docs/branch-sync-policy.md
+++ b/docs/branch-sync-policy.md
@@ -51,12 +51,9 @@ required posture:
 > The mapping table above is authoritative. If a ruleset and this table ever
 > disagree, update whichever is wrong so they match.
 
-> **Gap to reconcile.** The live `backplane-branches-lockdown` ruleset currently
-> includes only `backplane-5.0` and `backplane-5.1`; `backplane-5.2` is not yet a
-> member. Per the rule above, add `refs/heads/backplane-5.2` to that ruleset so its
-> enforcement matches this table. Until then, `backplane-5.2` is protected from
-> direct PRs by `protect-backplane-branches.yaml` but not from force-push/deletion
-> at the ruleset level.
+> **Note.** The `backplane-branches-lockdown` ruleset targets `backplane-5.0`,
+> `backplane-5.1`, and `backplane-5.2`. `backplane-5.2` was added after the initial
+> ARO-29174 rollout so the ruleset enforcement matches this table.
 
 > **Bot bypass required.** The FFWD and sync workflows push with the Actions
 > `GITHUB_TOKEN`. For those pushes to succeed against the protected

--- a/docs/branch-sync-policy.md
+++ b/docs/branch-sync-policy.md
@@ -112,8 +112,9 @@ customizations were silently reverted to their upstream form. This audit compare
   `mce-52-pull-request` (both present ✅). `mce-50` maps to `backplane-5.0`, which
   is fed from `release-2.18`, so its pull-request pipeline correctly lives on
   `release-2.18` (cel: `target_branch == "backplane-5.0" || target_branch ==
-  "release-2.18"`) rather than on `main`; it was added there by PR #472 (PR #471,
-  which had targeted `main`, was closed unmerged and superseded). `mce-217`
+  "release-2.18"`) rather than on `main`; PR #472 updated that pipeline's cel
+  expression to trigger on `release-2.18` pull requests (PR #471, which had
+  targeted `main`, was closed unmerged and superseded). `mce-217`
   likewise lives on `release-2.18`, and all `-push` pipelines target their own
   branches; none of these need to live on `main`.
 


### PR DESCRIPTION
## What & why

While verifying the ARO-29174 acceptance criteria against the live repo, I found that
every criterion is **implemented and working** — but `docs/branch-sync-policy.md` (the
designated source of truth) had drifted from reality. This PR corrects the doc only; no
workflow/ruleset behaviour changes.

## Fixes

1. **`release-2.18 → backplane-5.0` FFWD reference** — the doc linked to
   `ffwd-release-2.18.yaml`, which does not exist. The actual workflow is
   `ffwd-branch.yaml` on the `release-2.18` branch (verified: last run succeeded
   2026-08-31). Link now points at the file on that branch.

2. **mce-50 Tekton audit** — the doc claimed `mce-50-pull-request` should live on `main`
   and was "restored by PR #471." In reality `mce-50` maps to `backplane-5.0` (fed from
   `release-2.18`), so its pull-request pipeline correctly lives on `release-2.18` (cel:
   `backplane-5.0 || release-2.18`). That pipeline file already existed; **merged PR #472**
   retargeted its cel expression from `main` to `release-2.18`. **PR #471 (which targeted
   `main`) was closed unmerged and superseded.** Corrected.

3. **`backplane-5.2`** — `main` now fast-forwards into both `backplane-5.1` and
   `backplane-5.2` (via `ffwd-branch.yaml`; `mce-52` Tekton pipelines exist). Added
   `backplane-5.2` to the mapping table, the FFWD description, and the ruleset table.

4. **`backplane-5.2` ruleset membership** — `backplane-5.2` has now been added to the
   live `backplane-branches-lockdown` ruleset (`refs/heads/backplane-5.2`), so its
   non-fast-forward and deletion protection matches `backplane-5.0`/`5.1` and the table.
   The doc note reflects this resolved state.

Tracking: [ARO-29174](https://redhat.atlassian.net/browse/ARO-29174)

[ARO-29174]: https://redhat.atlassian.net/browse/ARO-29174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ