### PR TITLE
feat: add --tls-min-version flag for webhook and metrics servers (release-2.18)

### DIFF
--- a/v2/cmd/controller/app/setup.go
+++ b/v2/cmd/controller/app/setup.go
@@ -7,6 +7,7 @@ package app
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"math/rand"
 	"net/http"
@@ -93,6 +94,12 @@ func SetupControllerManager(ctx context.Context, setupLog logr.Logger, flgs *Fla
 		}
 	}
 
+	tlsOpts := []func(*tls.Config){
+		func(tlsCfg *tls.Config) {
+			tlsCfg.MinVersion = cfg.TLSMinVersion
+		},
+	}
+
 	k8sConfig := ctrl.GetConfigOrDie()
 	ctrlOptions := ctrl.Options{
 		Scheme: scheme,
@@ -117,10 +124,11 @@ func SetupControllerManager(ctx context.Context, setupLog logr.Logger, flgs *Fla
 		// flgs.EnableLeaderElection is true.
 		LeaderElectionReleaseOnCancel: flgs.EnableLeaderElection,
 		HealthProbeBindAddress:        flgs.HealthAddr,
-		Metrics:                       getMetricsOpts(flgs),
+		Metrics:                       getMetricsOpts(flgs, tlsOpts),
 		WebhookServer: webhook.NewServer(webhook.Options{
 			Port:    flgs.WebhookPort,
 			CertDir: flgs.WebhookCertDir,
+			TLSOpts: tlsOpts,
 		}),
 	}
 	mgr, err := ctrl.NewManager(k8sConfig, ctrlOptions)
@@ -251,7 +259,7 @@ func SetupControllerManager(ctx context.Context, setupLog logr.Logger, flgs *Fla
 	}
 }
 
-func getMetricsOpts(flags *Flags) server.Options {
+func getMetricsOpts(flags *Flags, tlsOpts []func(*tls.Config)) server.Options {
 	var metricsOptions server.Options
 
 	if flags.SecureMetrics {
@@ -259,6 +267,7 @@ func getMetricsOpts(flags *Flags) server.Options {
 			BindAddress:    flags.MetricsAddr,
 			SecureServing:  true,
 			FilterProvider: filters.WithAuthenticationAndAuthorization,
+			TLSOpts:        tlsOpts,
 		}
 		// Note that pprof endpoints are meant to be sensitive and shouldn't be exposed publicly.
 		if flags.ProfilingMetrics {

--- a/v2/internal/config/vars.go
+++ b/v2/internal/config/vars.go
@@ -4,6 +4,7 @@
 package config
 
 import (
+	"crypto/tls"
 	"fmt"
 	"os"
 	"strconv"
@@ -20,7 +21,37 @@ import (
 
 const (
 	DefaultSyncIntervalString = "1h"
+
+	// DefaultTLSMinVersion is the minimum TLS version used when TLS_MIN_VERSION is not set.
+	DefaultTLSMinVersion = "VersionTLS12"
 )
+
+// tlsVersionMap maps the supported TLS_MIN_VERSION string values to their crypto/tls constants.
+var tlsVersionMap = map[string]uint16{
+	"VersionTLS12": tls.VersionTLS12,
+	"VersionTLS13": tls.VersionTLS13,
+}
+
+// ParseTLSMinVersion converts a TLS_MIN_VERSION string value (for example "VersionTLS12")
+// into the corresponding crypto/tls version constant, returning an error for unsupported values.
+func ParseTLSMinVersion(s string) (uint16, error) {
+	v, ok := tlsVersionMap[s]
+	if !ok {
+		return 0, eris.Errorf("invalid TLS version %q, must be one of: VersionTLS12, VersionTLS13", s)
+	}
+	return v, nil
+}
+
+// tlsMinVersionName returns the string name for a TLS version constant, falling back to its
+// numeric value when the constant is not one of the supported values.
+func tlsMinVersionName(v uint16) string {
+	for name, val := range tlsVersionMap {
+		if val == v {
+			return name
+		}
+	}
+	return strconv.FormatUint(uint64(v), 10)
+}
 
 var (
 	DefaultMaxConcurrentReconciles = 1
@@ -119,6 +150,10 @@ type Values struct {
 	// When disabled, any attempt to specify these settings in a credential will cause reconciliation to fail.
 	// This defaults to false for security reasons.
 	AllowMultiEnvManagement bool
+
+	// TLSMinVersion is the minimum TLS version used by the webhook and metrics servers,
+	// stored as a crypto/tls version constant (for example tls.VersionTLS12).
+	TLSMinVersion uint16
 }
 
 type RateLimitMode string
@@ -200,7 +235,8 @@ func (v Values) String() string {
 	builder.WriteString(fmt.Sprintf("MaxConcurrentReconciles:%d/", v.MaxConcurrentReconciles))
 	builder.WriteString(fmt.Sprintf("RateLimit:[%s]/", v.RateLimit.String()))
 	builder.WriteString(fmt.Sprintf("DefaultReconcilePolicy:[%s]/", v.DefaultReconcilePolicy))
-	builder.WriteString(fmt.Sprintf("AllowMultiEnvManagement:%t", v.AllowMultiEnvManagement))
+	builder.WriteString(fmt.Sprintf("AllowMultiEnvManagement:%t/", v.AllowMultiEnvManagement))
+	builder.WriteString(fmt.Sprintf("TLSMinVersion:%s", tlsMinVersionName(v.TLSMinVersion)))
 
 	return builder.String()
 }
@@ -271,6 +307,11 @@ func ReadFromEnvironment() (Values, error) {
 
 	// Ignoring error here, as any other value or empty value means we should default to false
 	result.AllowMultiEnvManagement, _ = strconv.ParseBool(os.Getenv(config.AllowMultiEnvManagement))
+
+	result.TLSMinVersion, err = ParseTLSMinVersion(envOrDefault(config.TLSMinVersion, DefaultTLSMinVersion))
+	if err != nil {
+		return result, err
+	}
 
 	// Not calling validate here to support using from tests where we
 	// don't require consistent settings.

--- a/v2/internal/config/vars_test.go
+++ b/v2/internal/config/vars_test.go
@@ -4,6 +4,7 @@
 package config_test
 
 import (
+	"crypto/tls"
 	"reflect"
 	"testing"
 
@@ -79,6 +80,41 @@ func Test_Cloud_ResourceManagerAudienceSet(t *testing.T) {
 	g.Expect(cld.Services).To(HaveLen(1))
 	g.Expect(cld.Services[cloud.ResourceManager].Endpoint).To(Equal(cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint))
 	g.Expect(cld.Services[cloud.ResourceManager].Audience).To(Equal(cfg.ResourceManagerAudience))
+}
+
+func Test_ParseTLSMinVersion(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		input       string
+		expected    uint16
+		expectError bool
+	}{
+		{name: "TLS12 is valid", input: "VersionTLS12", expected: tls.VersionTLS12},
+		{name: "TLS13 is valid", input: "VersionTLS13", expected: tls.VersionTLS13},
+		{name: "matches the default", input: config.DefaultTLSMinVersion, expected: tls.VersionTLS12},
+		{name: "unsupported version is rejected", input: "TLSabcd", expectError: true},
+		{name: "TLS11 is rejected", input: "VersionTLS11", expectError: true},
+		{name: "empty value is rejected", input: "", expectError: true},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewGomegaWithT(t)
+
+			v, err := config.ParseTLSMinVersion(c.input)
+			if c.expectError {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err).To(MatchError(ContainSubstring(c.input)))
+				return
+			}
+
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(v).To(Equal(c.expected))
+		})
+	}
 }
 
 func TestValidate(t *testing.T) {

--- a/v2/pkg/common/config/config.go
+++ b/v2/pkg/common/config/config.go
@@ -107,4 +107,10 @@ const (
 	// When disabled, any attempt to specify these settings in a credential will cause reconciliation to fail.
 	// This defaults to false for security reasons.
 	AllowMultiEnvManagement = "ALLOW_MULTI_ENV_MANAGEMENT"
+	// EntraAppID is the client ID of the Entra application used to authenticate with Entra.
+	// NOTE: This is required when using Entra authentication, but optional otherwise.
+	EntraAppID = "ENTRA_APP_ID"
+	// TLSMinVersion is the minimum TLS version used by the webhook and metrics servers.
+	// If not specified, the default is "VersionTLS12". Valid values are "VersionTLS12" and "VersionTLS13".
+	TLSMinVersion = "TLS_MIN_VERSION"
 )


### PR DESCRIPTION
## Summary
- Cherry-pick of upstream Azure/azure-service-operator#5620 to `release-2.18`
- Adds `TLS_MIN_VERSION` env var (default `VersionTLS12`) to control the minimum TLS version used by the webhook and metrics servers
- Enables deployments requiring TLS 1.3 only (e.g. OpenShift Modern TLS profile) via `TLS_MIN_VERSION=VersionTLS13`
- Sourced from #518 (upstream sync PR)

## Test plan
- [ ] CI passes on this branch
- [ ] Verify controller starts with default TLS config
- [ ] Verify `TLS_MIN_VERSION=VersionTLS13` enforces TLS 1.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)