### PR TITLE
fix: remove 20240610preview API from ARO-HCP admin credentials retrieval

### DIFF
--- a/v2/api/redhatopenshift/customizations/hcp_open_shift_cluster_extension.go
+++ b/v2/api/redhatopenshift/customizations/hcp_open_shift_cluster_extension.go
@@ -9,7 +9,7 @@ import (
 
 	. "github.com/Azure/azure-service-operator/v2/internal/logging"
 
-	armstorage "github.com/Azure/ARO-HCP/test/sdk/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
+	armhcp20260630preview "github.com/Azure/ARO-HCP/test/sdk/v20260630preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/go-logr/logr"
 	"github.com/rotisserie/eris"
@@ -105,8 +105,8 @@ func (ext *HcpOpenShiftClusterExtension) ExportKubernetesSecrets(
 	subscription := id.SubscriptionID
 	// Using armClient.ClientOptions() here ensures we share the same HTTP connection, so this is not opening a new
 	// connection each time through
-	var clusterClient *armstorage.HcpOpenShiftClustersClient
-	clusterClient, err = armstorage.NewHcpOpenShiftClustersClient(subscription, armClient.Creds(), armClient.ClientOptions())
+	var clusterClient *armhcp20260630preview.HcpOpenShiftClustersClient
+	clusterClient, err = armhcp20260630preview.NewHcpOpenShiftClustersClient(subscription, armClient.Creds(), armClient.ClientOptions())
 	if err != nil {
 		return nil, eris.Wrapf(err, "failed to create new NewOpenShiftClustersClient")
 	}
@@ -114,7 +114,7 @@ func (ext *HcpOpenShiftClusterExtension) ExportKubernetesSecrets(
 	var adminCredentials string
 	if requestedSecrets.Contains(adminCredentialsKey) {
 		log.V(Debug).Info("Starting BeginRequestAdminCredential")
-		var poller *runtime.Poller[armstorage.HcpOpenShiftClustersClientRequestAdminCredentialResponse]
+		var poller *runtime.Poller[armhcp20260630preview.HcpOpenShiftClustersClientRequestAdminCredentialResponse]
 		poller, err = clusterClient.BeginRequestAdminCredential(ctx, id.ResourceGroupName, typedObj.AzureName(), nil)
 		if err != nil {
 			return nil, eris.Wrapf(err, "failed creating admin credentials")

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -3,7 +3,6 @@ module github.com/Azure/azure-service-operator/v2
 go 1.25.7
 
 require (
-	github.com/Azure/ARO-HCP/test/sdk/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp v0.0.0-20251215192205-b81971652ba7
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/apimanagement/armapimanagement/v2 v2.1.0
@@ -63,6 +62,8 @@ require (
 	sigs.k8s.io/controller-runtime v0.20.4
 	sigs.k8s.io/yaml v1.6.0
 )
+
+require github.com/Azure/ARO-HCP/test/sdk/v20260630preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp v0.0.0-20260901061919-8f3f7787bb89
 
 require (
 	cel.dev/expr v0.25.1 // indirect

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -41,8 +41,8 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 filippo.io/edwards25519 v1.1.1 h1:YpjwWWlNmGIDyXOn8zLzqiD+9TyIlPhGFG96P39uBpw=
 filippo.io/edwards25519 v1.1.1/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
-github.com/Azure/ARO-HCP/test/sdk/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp v0.0.0-20251215192205-b81971652ba7 h1:3DQqg7vfIu6PLN8NOcjr/6z/bMudzTD6gnCiRXWg6xw=
-github.com/Azure/ARO-HCP/test/sdk/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp v0.0.0-20251215192205-b81971652ba7/go.mod h1:Y1HQ9o+m8eF7AlWhKK+h2VZm9RmTNF1h+LxnY08TtrQ=
+github.com/Azure/ARO-HCP/test/sdk/v20260630preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp v0.0.0-20260901061919-8f3f7787bb89 h1:fWVxieKmAhgo3/h/dAPMv2WjDX6IgUEsB3Ch04gxYrk=
+github.com/Azure/ARO-HCP/test/sdk/v20260630preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp v0.0.0-20260901061919-8f3f7787bb89/go.mod h1:0g5JwVeLX4WIl2FlXVvhJkuQc+bdSFxQSRvFiOI4Ljg=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1 h1:jHb/wfvRikGdxMXYV3QG/SzUOPYN9KEUUuC0Yd0/vC0=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1/go.mod h1:pzBXCYn05zvYIrwLgtK8Ap8QcjRg+0i76tMQdWN6wOk=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1 h1:Hk5QBxZQC1jb2Fwj6mpzme37xbCDdNTxU7O9eb5+LB4=


### PR DESCRIPTION
https://redhat.atlassian.net/browse/ACM-43052

## What this PR does

This PR replaces the import of github.com/Azure/ARO-HCP/test/sdk/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp in  hcp_open_shift_cluster_extension.go with the import of 20260630preview

github.com/Azure/ARO-HCP/test/sdk/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp should not be used, as it is just an older version of the 20241223preview API, which is to be removed in near future.


_Thanks for sending a pull request! Delete this text and tell us why we need this change._

<!--  

Here are some tips:

If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. 
Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.

Closes #[issue number]
-->

<!--
### Special notes

_If there's anything complex or unusual about this PR that would help us review it, let us know here. Otherwise delete this section._
-->

## How does this PR make you feel?

![gif](https://giphy.com/)

## Checklist

<!--
_Delete any that don't apply. For completed items, change [ ] to [x]._
-->

- [ ] this PR contains documentation
- [ ] this PR contains tests
- [ ] this PR contains YAML Samples
