### PR TITLE
Backport SQL escaping improvements from upstream

### DIFF
--- a/v2/internal/util/azuresql/azuresql.go
+++ b/v2/internal/util/azuresql/azuresql.go
@@ -37,7 +37,8 @@ func ConnectToDB(
 		database,
 		user,
 		password,
-		port)
+		port,
+	)
 
 	db, err := sql.Open(driverName, connString)
 	if err != nil {
@@ -92,21 +93,18 @@ func CreateOrUpdateUser(ctx context.Context, db *sql.DB, username string, passwo
 	if err := findBadChars(username); err != nil {
 		return eris.Wrap(err, "problem found with username")
 	}
-	if err := findBadChars(password); err != nil {
-		return eris.Wrap(err, "problem found with password")
-	}
 
-	tsql := `
-IF NOT EXISTS (SELECT name FROM sysusers WHERE name='%[1]s')
+	//nolint:gosec // SQL identifiers cannot be parameterized; values are escaped for their SQL contexts.
+	tsql := fmt.Sprintf(`
+IF NOT EXISTS (SELECT name FROM sysusers WHERE name=%[1]s)
 	BEGIN
-		CREATE USER "%[1]s" WITH PASSWORD='%[2]s';
+		CREATE USER %[2]s WITH PASSWORD=%[3]s;
 	END
 ELSE
 	BEGIN
-		ALTER USER "%[1]s" WITH PASSWORD='%[2]s';
+		ALTER USER %[2]s WITH PASSWORD=%[3]s;
 	END;
-`
-	tsql = fmt.Sprintf(tsql, username, password)
+`, escapeStringLiteral(username), escapeIdentifier(username), escapeStringLiteral(password))
 	_, err := db.ExecContext(ctx, tsql)
 	if err != nil {
 		return err
@@ -170,6 +168,18 @@ func DropUser(ctx context.Context, db *sql.DB, username string) error {
 	tsql := fmt.Sprintf("DROP USER [%s]", username)
 	_, err := db.ExecContext(ctx, tsql)
 	return err
+}
+
+// escapeStringLiteral escapes and wraps a value for use as a SQL string literal.
+func escapeStringLiteral(value string) string {
+	escaped := strings.ReplaceAll(value, "'", "''")
+	return "'" + escaped + "'"
+}
+
+// escapeIdentifier escapes and wraps a value for use as a double-quoted SQL identifier.
+func escapeIdentifier(value string) string {
+	escaped := strings.ReplaceAll(value, "\"", "\"\"")
+	return "\"" + escaped + "\""
 }
 
 func findBadChars(str string) error {

--- a/v2/internal/util/azuresql/azuresql_test.go
+++ b/v2/internal/util/azuresql/azuresql_test.go
@@ -1,0 +1,152 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
+*/
+
+package azuresql
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestFindBadChars(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		input       string
+		expectError bool
+	}{
+		{
+			name:        "clean string passes",
+			input:       "validPassword123!@#",
+			expectError: false,
+		},
+		{
+			name:        "single quote fails",
+			input:       "pass'word",
+			expectError: true,
+		},
+		{
+			name:        "double quote fails",
+			input:       "pass\"word",
+			expectError: true,
+		},
+		{
+			name:        "semicolon fails",
+			input:       "pass;word",
+			expectError: true,
+		},
+		{
+			name:        "double dash fails",
+			input:       "pass--word",
+			expectError: true,
+		},
+		{
+			name:        "block comment fails",
+			input:       "pass/*word",
+			expectError: true,
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewGomegaWithT(t)
+
+			err := findBadChars(c.input)
+			if c.expectError {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
+			}
+		})
+	}
+}
+
+func TestEscapeStringLiteral(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "no special chars",
+			input:    "simplepassword",
+			expected: "'simplepassword'",
+		},
+		{
+			name:     "single quote is doubled",
+			input:    "pass'word",
+			expected: "'pass''word'",
+		},
+		{
+			name:     "semicolons are preserved",
+			input:    "pass;word",
+			expected: "'pass;word'",
+		},
+		{
+			name:     "double dashes are preserved",
+			input:    "pass--word",
+			expected: "'pass--word'",
+		},
+		{
+			name:     "complex special chars",
+			input:    "p@ss;w'rd--/*test",
+			expected: "'p@ss;w''rd--/*test'",
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewGomegaWithT(t)
+
+			result := escapeStringLiteral(c.input)
+			g.Expect(result).To(Equal(c.expected))
+		})
+	}
+}
+
+func TestEscapeIdentifier(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "no special chars",
+			input:    "username",
+			expected: "\"username\"",
+		},
+		{
+			name:     "double quote is doubled",
+			input:    "user\"name",
+			expected: "\"user\"\"name\"",
+		},
+		{
+			name:     "other special chars are preserved",
+			input:    "user;name",
+			expected: "\"user;name\"",
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewGomegaWithT(t)
+
+			result := escapeIdentifier(c.input)
+			g.Expect(result).To(Equal(c.expected))
+		})
+	}
+}

--- a/v2/internal/util/azuresql/role.go
+++ b/v2/internal/util/azuresql/role.go
@@ -61,7 +61,8 @@ where m.name = @user
 	rows, err := db.QueryContext(
 		ctx,
 		tsql,
-		sql.Named("user", user))
+		sql.Named("user", user),
+	)
 	if err != nil {
 		return nil, eris.Wrapf(err, "listing roles for user %s", user)
 	}

--- a/v2/internal/util/mysql/privilege.go
+++ b/v2/internal/util/mysql/privilege.go
@@ -77,7 +77,8 @@ func GetUserDatabasePrivileges(ctx context.Context, db *sql.DB, user string, hos
 	rows, err := db.QueryContext(
 		ctx,
 		"SELECT TABLE_SCHEMA, PRIVILEGE_TYPE FROM INFORMATION_SCHEMA.SCHEMA_PRIVILEGES WHERE GRANTEE = ?",
-		formatUser(user, hostname))
+		formatUser(user, hostname),
+	)
 	if err != nil {
 		return nil, eris.Wrapf(err, "listing database grants for user %s", user)
 	}
@@ -119,7 +120,8 @@ func GetUserServerPrivileges(ctx context.Context, db *sql.DB, user string, hostn
 	rows, err := db.QueryContext(
 		ctx,
 		"SELECT PRIVILEGE_TYPE FROM INFORMATION_SCHEMA.USER_PRIVILEGES WHERE GRANTEE = ? AND PRIVILEGE_TYPE != 'USAGE'",
-		formatUser(user, hostname))
+		formatUser(user, hostname),
+	)
 	if err != nil {
 		return nil, eris.Wrapf(err, "listing grants for user %s", user)
 	}

--- a/v2/internal/util/postgresql/postgresql.go
+++ b/v2/internal/util/postgresql/postgresql.go
@@ -42,15 +42,17 @@ func ConnectToDB(ctx context.Context, fullservername string, database string, po
 }
 
 func CreateUser(ctx context.Context, db *sql.DB, username string, password string) (*SQLUser, error) {
-	// make an effort to prevent sql injection
-	// TODO find better solution to check user and password for SQL Injection
 	if err := FindBadChars(username); err != nil {
 		return nil, eris.Wrap(err, "problem found with username")
 	}
-	if err := FindBadChars(password); err != nil {
-		return nil, eris.Wrap(err, "problem found with password")
-	}
-	_, err := db.ExecContext(ctx, fmt.Sprintf("CREATE USER \"%s\" WITH PASSWORD '%s'", username, password))
+	_, err := db.ExecContext(
+		ctx,
+		fmt.Sprintf(
+			"CREATE USER %s WITH PASSWORD %s",
+			escapeIdentifier(username),
+			escapeStringLiteral(password),
+		),
+	)
 	if err != nil {
 		return nil, eris.Wrapf(err, "failed to create user %s", username)
 	}
@@ -58,12 +60,14 @@ func CreateUser(ctx context.Context, db *sql.DB, username string, password strin
 }
 
 func UpdateUser(ctx context.Context, db *sql.DB, user SQLUser, password string) error {
-	// make an effort to prevent sql injection
-	// TODO find better solution to check password for SQL Injection
-	if err := FindBadChars(password); err != nil {
-		return eris.Wrap(err, "problem found with password")
-	}
-	_, err := db.ExecContext(ctx, fmt.Sprintf("ALTER USER \"%s\" WITH PASSWORD '%s'", user.Name, password))
+	_, err := db.ExecContext(
+		ctx,
+		fmt.Sprintf(
+			"ALTER USER %s WITH PASSWORD %s",
+			escapeIdentifier(user.Name),
+			escapeStringLiteral(password),
+		),
+	)
 	if err != nil {
 		return eris.Wrapf(err, "failed to alter user %s", user.Name)
 	}
@@ -99,7 +103,7 @@ func DropUser(ctx context.Context, db *sql.DB, user string) error {
 		return eris.Wrap(err, "problem found with username")
 	}
 
-	_, err := db.ExecContext(ctx, fmt.Sprintf("DROP USER IF EXISTS \"%s\"", user))
+	_, err := db.ExecContext(ctx, fmt.Sprintf("DROP USER IF EXISTS %s", escapeIdentifier(user)))
 	return err
 }
 
@@ -135,7 +139,7 @@ func CreateRoleWithPermissions(ctx context.Context, db *sql.DB, roleName string,
 		return eris.Wrap(err, "problem found with permissions")
 	}
 
-	_, err := db.ExecContext(ctx, fmt.Sprintf("CREATE ROLE %q WITH %s", roleName, permissionString))
+	_, err := db.ExecContext(ctx, fmt.Sprintf("CREATE ROLE %s WITH %s", escapeIdentifier(roleName), permissionString))
 	if err != nil {
 		return eris.Wrap(err, "failed to create role")
 	}
@@ -148,7 +152,25 @@ type SQLUser struct {
 	Name string
 }
 
-// FindBadChars find the bad chars in a postgresql user
+// escapeStringLiteral escapes a string for use as a PostgreSQL string literal.
+// It wraps the value in single quotes and escapes any internal single quotes by doubling them.
+// This is safe against SQL injection for string literals.
+func escapeStringLiteral(value string) string {
+	escaped := strings.ReplaceAll(value, "'", "''")
+	return "'" + escaped + "'"
+}
+
+// escapeIdentifier escapes a string for use as a PostgreSQL identifier (e.g., username, role name).
+// It wraps the value in double quotes and escapes any internal double quotes by doubling them.
+// This is safe against SQL injection for identifiers.
+func escapeIdentifier(value string) string {
+	escaped := strings.ReplaceAll(value, "\"", "\"\"")
+	return "\"" + escaped + "\""
+}
+
+// FindBadChars checks for potentially dangerous character sequences in identifiers like usernames and role names.
+// Note: This is still used for identifiers (usernames, role names) as an additional safety measure,
+// but is no longer used for passwords since proper escaping via EscapeStringLiteral handles all characters safely.
 func FindBadChars(stack string) error {
 	badChars := []string{
 		"'",

--- a/v2/internal/util/postgresql/postgresql_test.go
+++ b/v2/internal/util/postgresql/postgresql_test.go
@@ -1,0 +1,175 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package postgresql
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestFindBadChars(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		input       string
+		expectError bool
+	}{
+		{
+			name:        "clean string passes",
+			input:       "validPassword123!@#",
+			expectError: false,
+		},
+		{
+			name:        "single quote fails",
+			input:       "pass'word",
+			expectError: true,
+		},
+		{
+			name:        "double quote fails",
+			input:       "pass\"word",
+			expectError: true,
+		},
+		{
+			name:        "semicolon fails",
+			input:       "pass;word",
+			expectError: true,
+		},
+		{
+			name:        "double dash fails",
+			input:       "pass--word",
+			expectError: true,
+		},
+		{
+			name:        "block comment fails",
+			input:       "pass/*word",
+			expectError: true,
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewGomegaWithT(t)
+
+			err := FindBadChars(c.input)
+			if c.expectError {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
+			}
+		})
+	}
+}
+
+func TestEscapeStringLiteral(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "no special chars",
+			input:    "simplepassword",
+			expected: "'simplepassword'",
+		},
+		{
+			name:     "single quote is doubled",
+			input:    "pass'word",
+			expected: "'pass''word'",
+		},
+		{
+			name:     "multiple single quotes",
+			input:    "it's a test's password",
+			expected: "'it''s a test''s password'",
+		},
+		{
+			name:     "semicolons are preserved",
+			input:    "pass;word",
+			expected: "'pass;word'",
+		},
+		{
+			name:     "double dashes are preserved",
+			input:    "pass--word",
+			expected: "'pass--word'",
+		},
+		{
+			name:     "block comment is preserved",
+			input:    "pass/*word",
+			expected: "'pass/*word'",
+		},
+		{
+			name:     "double quotes are preserved",
+			input:    "pass\"word",
+			expected: "'pass\"word'",
+		},
+		{
+			name:     "complex special chars",
+			input:    "p@ss;w'rd--/*test",
+			expected: "'p@ss;w''rd--/*test'",
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "''",
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewGomegaWithT(t)
+
+			result := escapeStringLiteral(c.input)
+			g.Expect(result).To(Equal(c.expected))
+		})
+	}
+}
+
+func TestEscapeIdentifier(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "no special chars",
+			input:    "username",
+			expected: "\"username\"",
+		},
+		{
+			name:     "double quote is doubled",
+			input:    "user\"name",
+			expected: "\"user\"\"name\"",
+		},
+		{
+			name:     "multiple double quotes",
+			input:    "user\"na\"me",
+			expected: "\"user\"\"na\"\"me\"",
+		},
+		{
+			name:     "other special chars are preserved",
+			input:    "user;name",
+			expected: "\"user;name\"",
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewGomegaWithT(t)
+
+			result := escapeIdentifier(c.input)
+			g.Expect(result).To(Equal(c.expected))
+		})
+	}
+}

--- a/v2/internal/util/postgresql/role_option.go
+++ b/v2/internal/util/postgresql/role_option.go
@@ -82,7 +82,8 @@ func GetUserRoleOptions(ctx context.Context, db *sql.DB, user SQLUser) (*RoleOpt
 	rows, err := db.QueryContext(
 		ctx,
 		"SELECT rolcanlogin, rolcreaterole, rolcreatedb, rolreplication FROM pg_roles WHERE rolname !~ '^pg_' AND rolname = $1",
-		user.Name)
+		user.Name,
+	)
 	if err != nil {
 		return nil, eris.Wrapf(err, "listing grants for user %s", user)
 	}

--- a/v2/internal/util/postgresql/roles.go
+++ b/v2/internal/util/postgresql/roles.go
@@ -50,7 +50,8 @@ func GetUserServerRoles(ctx context.Context, db *sql.DB, user SQLUser) (set.Set[
 	rows, err := db.QueryContext(
 		ctx,
 		"SELECT c.rolname as role_name FROM pg_roles a INNER JOIN pg_auth_members b on a.oid = b.member INNER JOIN pg_roles c ON b.roleid = c.oid WHERE a.rolname = $1",
-		user.Name)
+		user.Name,
+	)
 	if err != nil {
 		return nil, eris.Wrapf(err, "listing grants for user %s", user)
 	}


### PR DESCRIPTION
## Summary
- Backport public upstream SQL escaping improvements
- Add `escapeIdentifier`/`escapeStringLiteral` for Azure SQL and PostgreSQL (upstream PR #5551)
- Use proper SQL escaping instead of raw `fmt.Sprintf` for passwords
- Include password error message fix (upstream PR #5401) and gofumpt formatting (#5359)
- Add unit tests for escape functions

## Test plan
- [x] `go build` passes for all three packages (azuresql, mysql, postgresql)
- [x] `go test` passes for all three packages
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)