### PR TITLE
dockerignore: remove v2 exclusion for ART/Konflux builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,6 +13,6 @@ cover-existing.html
 coverage-existing.txt
 report-existing.xml
 testlogs-existing.txt
-v2
-!v2/boilerplate.go.txt
+# v2 must NOT be excluded: the ART/Konflux Dockerfile (stolostron/Dockerfile.stolostron)
+# uses "COPY v2/ ./" and needs v2/ in the build context.
 .git


### PR DESCRIPTION
The ART Dockerfile (stolostron/Dockerfile.stolostron) uses 'COPY v2/ ./' to bring the Go module into the build container. However, .dockerignore excluded v2/ from the build context, causing buildah to silently copy nothing and 'go mod download' to fail with 'no modules specified'.

Remove the v2 exclusion so the full v2/ directory is available in the Docker build context. This is harmless for the upstream Dockerfile (which does not reference v2/) and fixes ART/Konflux builds.

Backport of #533 to release-2.18.

cc @smithbw88