### PR TITLE
samples: update ARO-HCP samples from v1api20260630preview to v1api20260901preview

### DIFF
--- a/v2/samples/redhatopenshift/v1api20260901preview/v1api20260901preview_hcpopenshiftcluster.yaml
+++ b/v2/samples/redhatopenshift/v1api20260901preview/v1api20260901preview_hcpopenshiftcluster.yaml
@@ -1,4 +1,4 @@
-apiVersion: redhatopenshift.azure.com/v1api20260630preview
+apiVersion: redhatopenshift.azure.com/v1api20260901preview
 kind: HcpOpenShiftCluster
 metadata:
   name: mveber-int

--- a/v2/samples/redhatopenshift/v1api20260901preview/v1api20260901preview_hcpopenshiftclustersexternalauth.yaml
+++ b/v2/samples/redhatopenshift/v1api20260901preview/v1api20260901preview_hcpopenshiftclustersexternalauth.yaml
@@ -1,4 +1,4 @@
-apiVersion: redhatopenshift.azure.com/v1api20260630preview
+apiVersion: redhatopenshift.azure.com/v1api20260901preview
 kind: HcpOpenShiftClustersExternalAuth
 metadata:
   name: mveber-int-ea

--- a/v2/samples/redhatopenshift/v1api20260901preview/v1api20260901preview_hcpopenshiftclustersnodepool.yaml
+++ b/v2/samples/redhatopenshift/v1api20260901preview/v1api20260901preview_hcpopenshiftclustersnodepool.yaml
@@ -1,4 +1,4 @@
-apiVersion: redhatopenshift.azure.com/v1api20260630preview
+apiVersion: redhatopenshift.azure.com/v1api20260901preview
 kind: HcpOpenShiftClustersNodePool
 metadata:
   name: mveber-int-mp-0


### PR DESCRIPTION
## Summary

- Rename sample directory and files from `v1api20260630preview` to `v1api20260901preview`
- Update `apiVersion` in each YAML from `redhatopenshift.azure.com/v1api20260630preview` to `redhatopenshift.azure.com/v1api20260901preview`

No field changes are required — the struct fields remain valid across both preview versions.

## Context

PR #535 switches the ARO-HCP hub API version from `2026-06-30-preview` to `2026-09-01-preview`, but the three sample files under `v2/samples/redhatopenshift/` were missed. This PR fixes that gap.

**Merge order**: must be merged after (or together with) PR #535.

## Files changed

```
v2/samples/redhatopenshift/
  v1api20260630preview/ (removed)  →  v1api20260901preview/ (added)
    v1api20260630preview_hcpopenshiftcluster.yaml
    v1api20260630preview_hcpopenshiftclustersexternalauth.yaml
    v1api20260630preview_hcpopenshiftclustersnodepool.yaml
```

## Jira

https://redhat.atlassian.net/browse/ARO-29438

🤖 Generated with [Claude Code](https://claude.com/claude-code)